### PR TITLE
Add routes service CRUD operations

### DIFF
--- a/api gateway/Gateway.API/Gateway.API/Controllers/RutasController.cs
+++ b/api gateway/Gateway.API/Gateway.API/Controllers/RutasController.cs
@@ -1,0 +1,37 @@
+using Gateway.API.GrpcClients;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Gateway.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class RutasController : ControllerBase
+{
+    private readonly RouteGrpcClient _grpcClient;
+
+    public RutasController(RouteGrpcClient grpcClient)
+    {
+        _grpcClient = grpcClient;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Get()
+    {
+        var rutas = await _grpcClient.ListarRutasAsync();
+        return Ok(rutas);
+    }
+
+    [HttpGet("ubicaciones")]
+    public async Task<IActionResult> GetUbicaciones()
+    {
+        var ubicaciones = await _grpcClient.ListarUbicacionesAsync();
+        return Ok(ubicaciones);
+    }
+
+    [HttpGet("segmentos")]
+    public async Task<IActionResult> GetSegmentos()
+    {
+        var segmentos = await _grpcClient.ListarSegmentosAsync();
+        return Ok(segmentos);
+    }
+}

--- a/api gateway/Gateway.API/Gateway.API/Gateway.API.csproj
+++ b/api gateway/Gateway.API/Gateway.API/Gateway.API.csproj
@@ -21,6 +21,7 @@
         <ItemGroup>
                 <Protobuf Include="Protos\vehicle.proto" GrpcServices="Client" />
                 <Protobuf Include="Protos\driver.proto" GrpcServices="Client" />
+                <Protobuf Include="Protos\routes.proto" GrpcServices="Client" />
         </ItemGroup>
 
 </Project>

--- a/api gateway/Gateway.API/Gateway.API/GrpcClients/DriverGrpcClient.cs
+++ b/api gateway/Gateway.API/Gateway.API/GrpcClients/DriverGrpcClient.cs
@@ -1,5 +1,4 @@
 using Grpc.Net.Client;
-using Gateway.API.Models;
 using Google.Protobuf.WellKnownTypes;
 using DriversService;
 
@@ -19,12 +18,12 @@ public class DriverGrpcClient
         _client = new DriverService.DriverServiceClient(channel);
     }
 
-    public async Task<IEnumerable<ConductorDto>> GetAllAsync()
+    public async Task<IEnumerable<Gateway.API.Models.ConductorDto>> GetAllAsync()
     {
         try
         {
             var response = await _client.ListarConductoresAsync(new Empty());
-            return response.Conductores.Select(c => new ConductorDto
+            return response.Conductores.Select(c => new Gateway.API.Models.ConductorDto
             {
                 ConductorId = c.ConductorId,
                 Codigo = c.Codigo,
@@ -48,12 +47,12 @@ public class DriverGrpcClient
         }
     }
 
-    public async Task<ConductorDto?> GetByIdAsync(int id)
+    public async Task<Gateway.API.Models.ConductorDto?> GetByIdAsync(int id)
     {
         try
         {
             var response = await _client.ObtenerConductorPorIdAsync(new ConductorIdRequest { ConductorId = id });
-            return new ConductorDto
+            return new Gateway.API.Models.ConductorDto
             {
                 ConductorId = response.ConductorId,
                 Codigo = response.Codigo,
@@ -81,11 +80,11 @@ public class DriverGrpcClient
         }
     }
 
-    public async Task<ConductorDto> CreateAsync(ConductorCreateRequest request)
+    public async Task<Gateway.API.Models.ConductorDto> CreateAsync(Gateway.API.Models.ConductorCreateRequest request)
     {
         try
         {
-            var grpcRequest = new ConductorCreateRequest
+            var grpcRequest = new DriversService.ConductorCreateRequest
             {
                 Codigo = request.Codigo,
                 Nombre = request.Nombre,
@@ -103,7 +102,7 @@ public class DriverGrpcClient
 
             var response = await _client.CrearConductorAsync(grpcRequest);
 
-            return new ConductorDto
+            return new Gateway.API.Models.ConductorDto
             {
                 ConductorId = response.ConductorId,
                 Codigo = response.Codigo,
@@ -127,11 +126,11 @@ public class DriverGrpcClient
         }
     }
 
-    public async Task<ConductorDto> UpdateAsync(int id, ConductorUpdateRequest request)
+    public async Task<Gateway.API.Models.ConductorDto> UpdateAsync(int id, Gateway.API.Models.ConductorUpdateRequest request)
     {
         try
         {
-            var grpcRequest = new ConductorUpdateRequest
+            var grpcRequest = new DriversService.ConductorUpdateRequest
             {
                 ConductorId = id
             };
@@ -151,7 +150,7 @@ public class DriverGrpcClient
 
             var response = await _client.EditarConductorAsync(grpcRequest);
 
-            return new ConductorDto
+            return new Gateway.API.Models.ConductorDto
             {
                 ConductorId = response.ConductorId,
                 Codigo = response.Codigo,

--- a/api gateway/Gateway.API/Gateway.API/GrpcClients/RouteGrpcClient.cs
+++ b/api gateway/Gateway.API/Gateway.API/GrpcClients/RouteGrpcClient.cs
@@ -1,0 +1,75 @@
+using Grpc.Net.Client;
+using Google.Protobuf.WellKnownTypes;
+using RoutesService;
+using ProtoRutaDto = RoutesService.RutaDto;
+using ProtoUbicacionDto = RoutesService.UbicacionDto;
+using ProtoSegmentoDto = RoutesService.SegmentoDto;
+
+namespace Gateway.API.GrpcClients;
+
+public class RouteGrpcClient
+{
+    private readonly RouteService.RouteServiceClient _client;
+
+    public RouteGrpcClient(IConfiguration configuration)
+    {
+        var url = configuration["GrpcSettings:RoutesService"];
+        if (string.IsNullOrWhiteSpace(url))
+            throw new InvalidOperationException("No se configur\u00f3 la URL del microservicio de rutas.");
+
+        var channel = GrpcChannel.ForAddress(url);
+        _client = new RouteService.RouteServiceClient(channel);
+    }
+
+    public async Task<IEnumerable<Gateway.API.Models.RutaDto>> ListarRutasAsync()
+    {
+        var response = await _client.ListarRutasAsync(new Empty());
+        return response.Rutas.Select(r => new Gateway.API.Models.RutaDto
+        {
+            RutaId = r.RutaId,
+            Codigo = r.Codigo,
+            Nombre = r.Nombre,
+            OrigenId = r.OrigenId,
+            DestinoId = r.DestinoId,
+            Distancia = r.Distancia,
+            TiempoEstimado = r.TiempoEstimado,
+            TipoTerreno = r.TipoTerreno,
+            Descripcion = r.Descripcion,
+            EstaActiva = r.EstaActiva
+        });
+    }
+
+    public async Task<IEnumerable<Gateway.API.Models.UbicacionDto>> ListarUbicacionesAsync()
+    {
+        var response = await _client.ListarUbicacionesAsync(new Empty());
+        return response.Ubicaciones.Select(u => new Gateway.API.Models.UbicacionDto
+        {
+            UbicacionId = u.UbicacionId,
+            Nombre = u.Nombre,
+            Direccion = u.Direccion,
+            Ciudad = u.Ciudad,
+            Estado = u.Estado,
+            Pais = u.Pais,
+            Latitud = u.Latitud,
+            Longitud = u.Longitud,
+            Tipo = u.Tipo
+        });
+    }
+
+    public async Task<IEnumerable<Gateway.API.Models.SegmentoDto>> ListarSegmentosAsync()
+    {
+        var response = await _client.ListarSegmentosAsync(new Empty());
+        return response.Segmentos.Select(s => new Gateway.API.Models.SegmentoDto
+        {
+            SegmentoId = s.SegmentoId,
+            RutaId = s.RutaId,
+            NumeroSecuencia = s.NumeroSecuencia,
+            UbicacionInicioId = s.UbicacionInicioId,
+            UbicacionFinId = s.UbicacionFinId,
+            DistanciaSegmento = s.DistanciaSegmento,
+            TiempoSegmento = s.TiempoSegmento,
+            TipoTerreno = s.TipoTerreno,
+            Descripcion = s.Descripcion
+        });
+    }
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/RutaDto.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/RutaDto.cs
@@ -1,0 +1,15 @@
+namespace Gateway.API.Models;
+
+public class RutaDto
+{
+    public int RutaId { get; set; }
+    public string Codigo { get; set; } = string.Empty;
+    public string Nombre { get; set; } = string.Empty;
+    public int OrigenId { get; set; }
+    public int DestinoId { get; set; }
+    public double Distancia { get; set; }
+    public double TiempoEstimado { get; set; }
+    public string? TipoTerreno { get; set; }
+    public string? Descripcion { get; set; }
+    public bool EstaActiva { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/SegmentoDto.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/SegmentoDto.cs
@@ -1,0 +1,14 @@
+namespace Gateway.API.Models;
+
+public class SegmentoDto
+{
+    public int SegmentoId { get; set; }
+    public int RutaId { get; set; }
+    public int NumeroSecuencia { get; set; }
+    public int UbicacionInicioId { get; set; }
+    public int UbicacionFinId { get; set; }
+    public double DistanciaSegmento { get; set; }
+    public double TiempoSegmento { get; set; }
+    public string? TipoTerreno { get; set; }
+    public string? Descripcion { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/UbicacionDto.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/UbicacionDto.cs
@@ -1,0 +1,14 @@
+namespace Gateway.API.Models;
+
+public class UbicacionDto
+{
+    public int UbicacionId { get; set; }
+    public string Nombre { get; set; } = string.Empty;
+    public string? Direccion { get; set; }
+    public string? Ciudad { get; set; }
+    public string? Estado { get; set; }
+    public string? Pais { get; set; }
+    public double Latitud { get; set; }
+    public double Longitud { get; set; }
+    public string? Tipo { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Program.cs
+++ b/api gateway/Gateway.API/Gateway.API/Program.cs
@@ -11,6 +11,7 @@ builder.Services.AddSwaggerGen();
 //Registro Cliente gRPC
 builder.Services.AddSingleton<VehiculoGrpcClient>();
 builder.Services.AddSingleton<DriverGrpcClient>();
+builder.Services.AddSingleton<RouteGrpcClient>();
 
 
 var app = builder.Build();

--- a/api gateway/Gateway.API/Gateway.API/Protos/routes.proto
+++ b/api gateway/Gateway.API/Gateway.API/Protos/routes.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+option csharp_namespace = "RoutesService";
+
+package routes;
+
+import "google/protobuf/empty.proto";
+
+message RutaDto {
+  int32 rutaId = 1;
+  string codigo = 2;
+  string nombre = 3;
+  int32 origenId = 4;
+  int32 destinoId = 5;
+  double distancia = 6;
+  double tiempoEstimado = 7;
+  string tipoTerreno = 8;
+  string descripcion = 9;
+  bool estaActiva = 10;
+}
+
+message UbicacionDto {
+  int32 ubicacionId = 1;
+  string nombre = 2;
+  string direccion = 3;
+  string ciudad = 4;
+  string estado = 5;
+  string pais = 6;
+  double latitud = 7;
+  double longitud = 8;
+  string tipo = 9;
+}
+
+message SegmentoDto {
+  int32 segmentoId = 1;
+  int32 rutaId = 2;
+  int32 numeroSecuencia = 3;
+  int32 ubicacionInicioId = 4;
+  int32 ubicacionFinId = 5;
+  double distanciaSegmento = 6;
+  double tiempoSegmento = 7;
+  string tipoTerreno = 8;
+  string descripcion = 9;
+}
+
+message ListaRutas { repeated RutaDto rutas = 1; }
+message ListaUbicaciones { repeated UbicacionDto ubicaciones = 1; }
+message ListaSegmentos { repeated SegmentoDto segmentos = 1; }
+
+service RouteService {
+  rpc ListarRutas (google.protobuf.Empty) returns (ListaRutas);
+  rpc ListarUbicaciones (google.protobuf.Empty) returns (ListaUbicaciones);
+  rpc ListarSegmentos (google.protobuf.Empty) returns (ListaSegmentos);
+}

--- a/api gateway/Gateway.API/Gateway.API/appsettings.json
+++ b/api gateway/Gateway.API/Gateway.API/appsettings.json
@@ -1,7 +1,8 @@
 {
     "GrpcSettings": {
         "VehiclesService": "http://localhost:5117",
-        "DriversService": "http://localhost:5120"
+        "DriversService": "http://localhost:5120",
+        "RoutesService": "http://localhost:5123"
     },
     "Logging": {
         "LogLevel": {

--- a/routes-service/README.md
+++ b/routes-service/README.md
@@ -1,0 +1,3 @@
+# Routes Service
+
+Microservicio gRPC para manejo de rutas, ubicaciones y segmentos.

--- a/routes-service/routes-service.sln
+++ b/routes-service/routes-service.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35913.81 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "routes-service", "routes-service\routes-service.csproj", "{E9BD5BFC-ABBC-4FC6-9A01-AD8D57B22F8C}"
+EndProject
+Global
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Release|Any CPU = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {E9BD5BFC-ABBC-4FC6-9A01-AD8D57B22F8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E9BD5BFC-ABBC-4FC6-9A01-AD8D57B22F8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E9BD5BFC-ABBC-4FC6-9A01-AD8D57B22F8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E9BD5BFC-ABBC-4FC6-9A01-AD8D57B22F8C}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
+        GlobalSection(ExtensibilityGlobals) = postSolution
+                SolutionGuid = {CB0645DB-5BA7-4C38-A03A-293CD7604AF7}
+        EndGlobalSection
+EndGlobal

--- a/routes-service/routes-service/Dockerfile
+++ b/routes-service/routes-service/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+USER $APP_UID
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["routes-service.csproj", "."]
+RUN dotnet restore "./routes-service.csproj"
+COPY . .
+RUN dotnet build "./routes-service.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "./routes-service.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "routes-service.dll"]

--- a/routes-service/routes-service/Domain/Entities/Ruta.cs
+++ b/routes-service/routes-service/Domain/Entities/Ruta.cs
@@ -1,0 +1,19 @@
+namespace RoutesService.Domain.Entities;
+
+public class Ruta
+{
+    public int RutaId { get; set; }
+    public required string Codigo { get; set; }
+    public required string Nombre { get; set; }
+    public int OrigenId { get; set; }
+    public int DestinoId { get; set; }
+    public decimal Distancia { get; set; }
+    public decimal TiempoEstimado { get; set; }
+    public string? TipoTerreno { get; set; }
+    public string? Descripcion { get; set; }
+    public bool EstaActiva { get; set; }
+    public DateTime CreadoEn { get; set; }
+    public DateTime? ActualizadoEn { get; set; }
+
+    public ICollection<SegmentoRuta>? Segmentos { get; set; }
+}

--- a/routes-service/routes-service/Domain/Entities/SegmentoRuta.cs
+++ b/routes-service/routes-service/Domain/Entities/SegmentoRuta.cs
@@ -1,0 +1,18 @@
+namespace RoutesService.Domain.Entities;
+
+public class SegmentoRuta
+{
+    public int SegmentoId { get; set; }
+    public int RutaId { get; set; }
+    public int NumeroSecuencia { get; set; }
+    public int UbicacionInicioId { get; set; }
+    public int UbicacionFinId { get; set; }
+    public decimal DistanciaSegmento { get; set; }
+    public decimal TiempoSegmento { get; set; }
+    public string? TipoTerreno { get; set; }
+    public string? Descripcion { get; set; }
+    public DateTime CreadoEn { get; set; }
+    public DateTime? ActualizadoEn { get; set; }
+
+    public Ruta? Ruta { get; set; }
+}

--- a/routes-service/routes-service/Domain/Entities/Ubicacion.cs
+++ b/routes-service/routes-service/Domain/Entities/Ubicacion.cs
@@ -1,0 +1,16 @@
+namespace RoutesService.Domain.Entities;
+
+public class Ubicacion
+{
+    public int UbicacionId { get; set; }
+    public required string Nombre { get; set; }
+    public string? Direccion { get; set; }
+    public string? Ciudad { get; set; }
+    public string? Estado { get; set; }
+    public string? Pais { get; set; }
+    public decimal? Latitud { get; set; }
+    public decimal? Longitud { get; set; }
+    public string? Tipo { get; set; }
+    public DateTime CreadoEn { get; set; }
+    public DateTime? ActualizadoEn { get; set; }
+}

--- a/routes-service/routes-service/Persistence/RoutesDbContext.cs
+++ b/routes-service/routes-service/Persistence/RoutesDbContext.cs
@@ -1,0 +1,64 @@
+using Microsoft.EntityFrameworkCore;
+using RoutesService.Domain.Entities;
+
+namespace RoutesService.Persistence;
+
+public class RoutesDbContext : DbContext
+{
+    public RoutesDbContext(DbContextOptions<RoutesDbContext> options) : base(options) { }
+
+    public DbSet<Ruta> Rutas => Set<Ruta>();
+    public DbSet<Ubicacion> Ubicaciones => Set<Ubicacion>();
+    public DbSet<SegmentoRuta> Segmentos => Set<SegmentoRuta>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Ruta>().ToTable("rutas");
+        modelBuilder.Entity<Ubicacion>().ToTable("ubicaciones");
+        modelBuilder.Entity<SegmentoRuta>().ToTable("segmentos_ruta");
+
+        var ruta = modelBuilder.Entity<Ruta>();
+        ruta.HasKey(r => r.RutaId);
+        ruta.Property(r => r.RutaId).HasColumnName("ruta_id");
+        ruta.Property(r => r.Codigo).HasColumnName("codigo");
+        ruta.Property(r => r.Nombre).HasColumnName("nombre");
+        ruta.Property(r => r.OrigenId).HasColumnName("origen_id");
+        ruta.Property(r => r.DestinoId).HasColumnName("destino_id");
+        ruta.Property(r => r.Distancia).HasColumnName("distancia");
+        ruta.Property(r => r.TiempoEstimado).HasColumnName("tiempo_estimado");
+        ruta.Property(r => r.TipoTerreno).HasColumnName("tipo_terreno");
+        ruta.Property(r => r.Descripcion).HasColumnName("descripcion");
+        ruta.Property(r => r.EstaActiva).HasColumnName("esta_activa");
+        ruta.Property(r => r.CreadoEn).HasColumnName("creado_en");
+        ruta.Property(r => r.ActualizadoEn).HasColumnName("actualizado_en");
+
+        var ubi = modelBuilder.Entity<Ubicacion>();
+        ubi.HasKey(u => u.UbicacionId);
+        ubi.Property(u => u.UbicacionId).HasColumnName("ubicacion_id");
+        ubi.Property(u => u.Nombre).HasColumnName("nombre");
+        ubi.Property(u => u.Direccion).HasColumnName("direccion");
+        ubi.Property(u => u.Ciudad).HasColumnName("ciudad");
+        ubi.Property(u => u.Estado).HasColumnName("estado");
+        ubi.Property(u => u.Pais).HasColumnName("pais");
+        ubi.Property(u => u.Latitud).HasColumnName("latitud");
+        ubi.Property(u => u.Longitud).HasColumnName("longitud");
+        ubi.Property(u => u.Tipo).HasColumnName("tipo");
+        ubi.Property(u => u.CreadoEn).HasColumnName("creado_en");
+        ubi.Property(u => u.ActualizadoEn).HasColumnName("actualizado_en");
+
+        var seg = modelBuilder.Entity<SegmentoRuta>();
+        seg.HasKey(s => s.SegmentoId);
+        seg.Property(s => s.SegmentoId).HasColumnName("segmento_id");
+        seg.Property(s => s.RutaId).HasColumnName("ruta_id");
+        seg.Property(s => s.NumeroSecuencia).HasColumnName("numero_secuencia");
+        seg.Property(s => s.UbicacionInicioId).HasColumnName("ubicacion_inicio_id");
+        seg.Property(s => s.UbicacionFinId).HasColumnName("ubicacion_fin_id");
+        seg.Property(s => s.DistanciaSegmento).HasColumnName("distancia_segmento");
+        seg.Property(s => s.TiempoSegmento).HasColumnName("tiempo_segmento");
+        seg.Property(s => s.TipoTerreno).HasColumnName("tipo_terreno");
+        seg.Property(s => s.Descripcion).HasColumnName("descripcion");
+        seg.Property(s => s.CreadoEn).HasColumnName("creado_en");
+        seg.Property(s => s.ActualizadoEn).HasColumnName("actualizado_en");
+        seg.HasOne(s => s.Ruta).WithMany(r => r.Segmentos).HasForeignKey(s => s.RutaId);
+    }
+}

--- a/routes-service/routes-service/Program.cs
+++ b/routes-service/routes-service/Program.cs
@@ -1,0 +1,16 @@
+using RoutesService.Persistence;
+using RoutesService.Services;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddGrpc();
+builder.Services.AddDbContext<RoutesDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+var app = builder.Build();
+
+app.MapGrpcService<RouteGrpcService>();
+app.MapGet("/", () => "gRPC service for routes");
+
+app.Run();

--- a/routes-service/routes-service/Properties/launchSettings.json
+++ b/routes-service/routes-service/Properties/launchSettings.json
@@ -1,0 +1,46 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5117"
+    },
+    "https": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:7065;http://localhost:5117"
+    },
+    "Container (Dockerfile)": {
+      "commandName": "Docker",
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}",
+      "environmentVariables": {
+        "ASPNETCORE_HTTPS_PORTS": "8081",
+        "ASPNETCORE_HTTP_PORTS": "8080"
+      },
+      "publishAllPorts": true,
+      "useSSL": true
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:62539/",
+      "sslPort": 44380
+    }
+  }
+}

--- a/routes-service/routes-service/Protos/routes.proto
+++ b/routes-service/routes-service/Protos/routes.proto
@@ -1,0 +1,145 @@
+syntax = "proto3";
+
+option csharp_namespace = "RoutesService";
+
+package routes;
+
+import "google/protobuf/empty.proto";
+
+message RutaDto {
+  int32 rutaId = 1;
+  string codigo = 2;
+  string nombre = 3;
+  int32 origenId = 4;
+  int32 destinoId = 5;
+  double distancia = 6;
+  double tiempoEstimado = 7;
+  string tipoTerreno = 8;
+  string descripcion = 9;
+  bool estaActiva = 10;
+}
+
+message RutaCreateRequest {
+  string codigo = 1;
+  string nombre = 2;
+  int32 origenId = 3;
+  int32 destinoId = 4;
+  double distancia = 5;
+  double tiempoEstimado = 6;
+  string tipoTerreno = 7;
+  string descripcion = 8;
+  bool estaActiva = 9;
+}
+
+message RutaIdRequest { int32 rutaId = 1; }
+
+message RutaUpdateRequest {
+  int32 rutaId = 1;
+  optional string codigo = 2;
+  optional string nombre = 3;
+  optional int32 origenId = 4;
+  optional int32 destinoId = 5;
+  optional double distancia = 6;
+  optional double tiempoEstimado = 7;
+  optional string tipoTerreno = 8;
+  optional string descripcion = 9;
+  optional bool estaActiva = 10;
+}
+
+message UbicacionDto {
+  int32 ubicacionId = 1;
+  string nombre = 2;
+  string direccion = 3;
+  string ciudad = 4;
+  string estado = 5;
+  string pais = 6;
+  double latitud = 7;
+  double longitud = 8;
+  string tipo = 9;
+}
+
+message UbicacionCreateRequest {
+  string nombre = 1;
+  string direccion = 2;
+  string ciudad = 3;
+  string estado = 4;
+  string pais = 5;
+  double latitud = 6;
+  double longitud = 7;
+  string tipo = 8;
+}
+
+message UbicacionIdRequest { int32 ubicacionId = 1; }
+
+message UbicacionUpdateRequest {
+  int32 ubicacionId = 1;
+  optional string nombre = 2;
+  optional string direccion = 3;
+  optional string ciudad = 4;
+  optional string estado = 5;
+  optional string pais = 6;
+  optional double latitud = 7;
+  optional double longitud = 8;
+  optional string tipo = 9;
+}
+
+message SegmentoDto {
+  int32 segmentoId = 1;
+  int32 rutaId = 2;
+  int32 numeroSecuencia = 3;
+  int32 ubicacionInicioId = 4;
+  int32 ubicacionFinId = 5;
+  double distanciaSegmento = 6;
+  double tiempoSegmento = 7;
+  string tipoTerreno = 8;
+  string descripcion = 9;
+}
+
+message SegmentoCreateRequest {
+  int32 rutaId = 1;
+  int32 numeroSecuencia = 2;
+  int32 ubicacionInicioId = 3;
+  int32 ubicacionFinId = 4;
+  double distanciaSegmento = 5;
+  double tiempoSegmento = 6;
+  string tipoTerreno = 7;
+  string descripcion = 8;
+}
+
+message SegmentoIdRequest { int32 segmentoId = 1; }
+
+message SegmentoUpdateRequest {
+  int32 segmentoId = 1;
+  optional int32 rutaId = 2;
+  optional int32 numeroSecuencia = 3;
+  optional int32 ubicacionInicioId = 4;
+  optional int32 ubicacionFinId = 5;
+  optional double distanciaSegmento = 6;
+  optional double tiempoSegmento = 7;
+  optional string tipoTerreno = 8;
+  optional string descripcion = 9;
+}
+
+message ListaRutas { repeated RutaDto rutas = 1; }
+message ListaUbicaciones { repeated UbicacionDto ubicaciones = 1; }
+message ListaSegmentos { repeated SegmentoDto segmentos = 1; }
+
+service RouteService {
+  rpc CrearRuta (RutaCreateRequest) returns (RutaDto);
+  rpc ObtenerRutaPorId (RutaIdRequest) returns (RutaDto);
+  rpc ListarRutas (google.protobuf.Empty) returns (ListaRutas);
+  rpc EditarRuta (RutaUpdateRequest) returns (RutaDto);
+  rpc EliminarRuta (RutaIdRequest) returns (google.protobuf.Empty);
+
+  rpc CrearUbicacion (UbicacionCreateRequest) returns (UbicacionDto);
+  rpc ObtenerUbicacionPorId (UbicacionIdRequest) returns (UbicacionDto);
+  rpc ListarUbicaciones (google.protobuf.Empty) returns (ListaUbicaciones);
+  rpc EditarUbicacion (UbicacionUpdateRequest) returns (UbicacionDto);
+  rpc EliminarUbicacion (UbicacionIdRequest) returns (google.protobuf.Empty);
+
+  rpc CrearSegmento (SegmentoCreateRequest) returns (SegmentoDto);
+  rpc ObtenerSegmentoPorId (SegmentoIdRequest) returns (SegmentoDto);
+  rpc ListarSegmentos (google.protobuf.Empty) returns (ListaSegmentos);
+  rpc EditarSegmento (SegmentoUpdateRequest) returns (SegmentoDto);
+  rpc EliminarSegmento (SegmentoIdRequest) returns (google.protobuf.Empty);
+}

--- a/routes-service/routes-service/Services/RouteGrpcService.cs
+++ b/routes-service/routes-service/Services/RouteGrpcService.cs
@@ -1,0 +1,260 @@
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Microsoft.EntityFrameworkCore;
+using RoutesService.Domain.Entities;
+using RoutesService.Persistence;
+
+namespace RoutesService.Services;
+
+public class RouteGrpcService : RouteService.RouteServiceBase
+{
+    private readonly RoutesDbContext _context;
+
+    public RouteGrpcService(RoutesDbContext context)
+    {
+        _context = context;
+    }
+
+    private static RutaDto ToRutaDto(Ruta r) => new()
+    {
+        RutaId = r.RutaId,
+        Codigo = r.Codigo,
+        Nombre = r.Nombre,
+        OrigenId = r.OrigenId,
+        DestinoId = r.DestinoId,
+        Distancia = (double)r.Distancia,
+        TiempoEstimado = (double)r.TiempoEstimado,
+        TipoTerreno = r.TipoTerreno ?? string.Empty,
+        Descripcion = r.Descripcion ?? string.Empty,
+        EstaActiva = r.EstaActiva
+    };
+
+    private static UbicacionDto ToUbicacionDto(Ubicacion u) => new()
+    {
+        UbicacionId = u.UbicacionId,
+        Nombre = u.Nombre,
+        Direccion = u.Direccion ?? string.Empty,
+        Ciudad = u.Ciudad ?? string.Empty,
+        Estado = u.Estado ?? string.Empty,
+        Pais = u.Pais ?? string.Empty,
+        Latitud = (double)(u.Latitud ?? 0),
+        Longitud = (double)(u.Longitud ?? 0),
+        Tipo = u.Tipo ?? string.Empty
+    };
+
+    private static SegmentoDto ToSegmentoDto(SegmentoRuta s) => new()
+    {
+        SegmentoId = s.SegmentoId,
+        RutaId = s.RutaId,
+        NumeroSecuencia = s.NumeroSecuencia,
+        UbicacionInicioId = s.UbicacionInicioId,
+        UbicacionFinId = s.UbicacionFinId,
+        DistanciaSegmento = (double)s.DistanciaSegmento,
+        TiempoSegmento = (double)s.TiempoSegmento,
+        TipoTerreno = s.TipoTerreno ?? string.Empty,
+        Descripcion = s.Descripcion ?? string.Empty
+    };
+
+    public override async Task<RutaDto> CrearRuta(RutaCreateRequest request, ServerCallContext context)
+    {
+        var ruta = new Ruta
+        {
+            Codigo = request.Codigo,
+            Nombre = request.Nombre,
+            OrigenId = request.OrigenId,
+            DestinoId = request.DestinoId,
+            Distancia = (decimal)request.Distancia,
+            TiempoEstimado = (decimal)request.TiempoEstimado,
+            TipoTerreno = request.TipoTerreno,
+            Descripcion = request.Descripcion,
+            EstaActiva = request.EstaActiva,
+            CreadoEn = DateTime.UtcNow
+        };
+
+        _context.Rutas.Add(ruta);
+        await _context.SaveChangesAsync();
+        return ToRutaDto(ruta);
+    }
+
+    public override async Task<RutaDto> ObtenerRutaPorId(RutaIdRequest request, ServerCallContext context)
+    {
+        var ruta = await _context.Rutas.FindAsync(request.RutaId);
+        if (ruta == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Ruta no encontrada"));
+        return ToRutaDto(ruta);
+    }
+
+    public override async Task<RutaDto> EditarRuta(RutaUpdateRequest request, ServerCallContext context)
+    {
+        var ruta = await _context.Rutas.FindAsync(request.RutaId);
+        if (ruta == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Ruta no encontrada"));
+
+        if (request.HasCodigo) ruta.Codigo = request.Codigo;
+        if (request.HasNombre) ruta.Nombre = request.Nombre;
+        if (request.HasOrigenId) ruta.OrigenId = request.OrigenId;
+        if (request.HasDestinoId) ruta.DestinoId = request.DestinoId;
+        if (request.HasDistancia) ruta.Distancia = (decimal)request.Distancia;
+        if (request.HasTiempoEstimado) ruta.TiempoEstimado = (decimal)request.TiempoEstimado;
+        if (request.HasTipoTerreno) ruta.TipoTerreno = request.TipoTerreno;
+        if (request.HasDescripcion) ruta.Descripcion = request.Descripcion;
+        if (request.HasEstaActiva) ruta.EstaActiva = request.EstaActiva;
+
+        ruta.ActualizadoEn = DateTime.UtcNow;
+        await _context.SaveChangesAsync();
+        return ToRutaDto(ruta);
+    }
+
+    public override async Task<Empty> EliminarRuta(RutaIdRequest request, ServerCallContext context)
+    {
+        var ruta = await _context.Rutas.FindAsync(request.RutaId);
+        if (ruta == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Ruta no encontrada"));
+
+        _context.Rutas.Remove(ruta);
+        await _context.SaveChangesAsync();
+        return new Empty();
+    }
+
+    public override async Task<UbicacionDto> CrearUbicacion(UbicacionCreateRequest request, ServerCallContext context)
+    {
+        var ubicacion = new Ubicacion
+        {
+            Nombre = request.Nombre,
+            Direccion = request.Direccion,
+            Ciudad = request.Ciudad,
+            Estado = request.Estado,
+            Pais = request.Pais,
+            Latitud = (decimal)request.Latitud,
+            Longitud = (decimal)request.Longitud,
+            Tipo = request.Tipo,
+            CreadoEn = DateTime.UtcNow
+        };
+
+        _context.Ubicaciones.Add(ubicacion);
+        await _context.SaveChangesAsync();
+        return ToUbicacionDto(ubicacion);
+    }
+
+    public override async Task<UbicacionDto> ObtenerUbicacionPorId(UbicacionIdRequest request, ServerCallContext context)
+    {
+        var ubicacion = await _context.Ubicaciones.FindAsync(request.UbicacionId);
+        if (ubicacion == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Ubicación no encontrada"));
+        return ToUbicacionDto(ubicacion);
+    }
+
+    public override async Task<UbicacionDto> EditarUbicacion(UbicacionUpdateRequest request, ServerCallContext context)
+    {
+        var ubicacion = await _context.Ubicaciones.FindAsync(request.UbicacionId);
+        if (ubicacion == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Ubicación no encontrada"));
+
+        if (request.HasNombre) ubicacion.Nombre = request.Nombre;
+        if (request.HasDireccion) ubicacion.Direccion = request.Direccion;
+        if (request.HasCiudad) ubicacion.Ciudad = request.Ciudad;
+        if (request.HasEstado) ubicacion.Estado = request.Estado;
+        if (request.HasPais) ubicacion.Pais = request.Pais;
+        if (request.HasLatitud) ubicacion.Latitud = (decimal)request.Latitud;
+        if (request.HasLongitud) ubicacion.Longitud = (decimal)request.Longitud;
+        if (request.HasTipo) ubicacion.Tipo = request.Tipo;
+
+        ubicacion.ActualizadoEn = DateTime.UtcNow;
+        await _context.SaveChangesAsync();
+        return ToUbicacionDto(ubicacion);
+    }
+
+    public override async Task<Empty> EliminarUbicacion(UbicacionIdRequest request, ServerCallContext context)
+    {
+        var ubicacion = await _context.Ubicaciones.FindAsync(request.UbicacionId);
+        if (ubicacion == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Ubicación no encontrada"));
+
+        _context.Ubicaciones.Remove(ubicacion);
+        await _context.SaveChangesAsync();
+        return new Empty();
+    }
+
+    public override async Task<SegmentoDto> CrearSegmento(SegmentoCreateRequest request, ServerCallContext context)
+    {
+        var segmento = new SegmentoRuta
+        {
+            RutaId = request.RutaId,
+            NumeroSecuencia = request.NumeroSecuencia,
+            UbicacionInicioId = request.UbicacionInicioId,
+            UbicacionFinId = request.UbicacionFinId,
+            DistanciaSegmento = (decimal)request.DistanciaSegmento,
+            TiempoSegmento = (decimal)request.TiempoSegmento,
+            TipoTerreno = request.TipoTerreno,
+            Descripcion = request.Descripcion,
+            CreadoEn = DateTime.UtcNow
+        };
+
+        _context.Segmentos.Add(segmento);
+        await _context.SaveChangesAsync();
+        return ToSegmentoDto(segmento);
+    }
+
+    public override async Task<SegmentoDto> ObtenerSegmentoPorId(SegmentoIdRequest request, ServerCallContext context)
+    {
+        var segmento = await _context.Segmentos.FindAsync(request.SegmentoId);
+        if (segmento == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Segmento no encontrado"));
+        return ToSegmentoDto(segmento);
+    }
+
+    public override async Task<SegmentoDto> EditarSegmento(SegmentoUpdateRequest request, ServerCallContext context)
+    {
+        var segmento = await _context.Segmentos.FindAsync(request.SegmentoId);
+        if (segmento == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Segmento no encontrado"));
+
+        if (request.HasRutaId) segmento.RutaId = request.RutaId;
+        if (request.HasNumeroSecuencia) segmento.NumeroSecuencia = request.NumeroSecuencia;
+        if (request.HasUbicacionInicioId) segmento.UbicacionInicioId = request.UbicacionInicioId;
+        if (request.HasUbicacionFinId) segmento.UbicacionFinId = request.UbicacionFinId;
+        if (request.HasDistanciaSegmento) segmento.DistanciaSegmento = (decimal)request.DistanciaSegmento;
+        if (request.HasTiempoSegmento) segmento.TiempoSegmento = (decimal)request.TiempoSegmento;
+        if (request.HasTipoTerreno) segmento.TipoTerreno = request.TipoTerreno;
+        if (request.HasDescripcion) segmento.Descripcion = request.Descripcion;
+
+        segmento.ActualizadoEn = DateTime.UtcNow;
+        await _context.SaveChangesAsync();
+        return ToSegmentoDto(segmento);
+    }
+
+    public override async Task<Empty> EliminarSegmento(SegmentoIdRequest request, ServerCallContext context)
+    {
+        var segmento = await _context.Segmentos.FindAsync(request.SegmentoId);
+        if (segmento == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Segmento no encontrado"));
+
+        _context.Segmentos.Remove(segmento);
+        await _context.SaveChangesAsync();
+        return new Empty();
+    }
+
+    public override async Task<ListaRutas> ListarRutas(Empty request, ServerCallContext context)
+    {
+        var list = await _context.Rutas.ToListAsync();
+        var res = new ListaRutas();
+        res.Rutas.AddRange(list.Select(ToRutaDto));
+        return res;
+    }
+
+    public override async Task<ListaUbicaciones> ListarUbicaciones(Empty request, ServerCallContext context)
+    {
+        var list = await _context.Ubicaciones.ToListAsync();
+        var res = new ListaUbicaciones();
+        res.Ubicaciones.AddRange(list.Select(ToUbicacionDto));
+        return res;
+    }
+
+    public override async Task<ListaSegmentos> ListarSegmentos(Empty request, ServerCallContext context)
+    {
+        var list = await _context.Segmentos.ToListAsync();
+        var res = new ListaSegmentos();
+        res.Segmentos.AddRange(list.Select(ToSegmentoDto));
+        return res;
+    }
+}

--- a/routes-service/routes-service/appsettings.json
+++ b/routes-service/routes-service/appsettings.json
@@ -1,0 +1,17 @@
+{
+    "ConnectionStrings": {
+        "DefaultConnection": "Server=localhost;Database=routes_db;Trusted_Connection=True;TrustServerCertificate=True;"
+    },
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*",
+    "Kestrel": {
+        "EndpointDefaults": {
+            "Protocols": "Http2"
+        }
+    }
+}

--- a/routes-service/routes-service/routes-service.csproj
+++ b/routes-service/routes-service/routes-service.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
+  <ItemGroup>
+    <Protobuf Include="Protos\routes.proto" GrpcServices="Server" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Grpc.Tools" Version="2.71.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Google.Protobuf" Version="3.30.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- extend `routes.proto` with create, update, delete and get methods
- implement full CRUD in `RouteGrpcService`
- adjust gRPC clients to avoid type clashes
- ensure Gateway and routes microservice build successfully

## Testing
- `dotnet build routes-service/routes-service/routes-service.csproj -c Release`
- `dotnet build "api gateway/Gateway.API/Gateway.API/Gateway.API.csproj" -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6862fd3fa5b08333b2f72c00cb4e4d22