### PR TITLE
Add fuel-service microservice

### DIFF
--- a/api gateway/Gateway.API/Gateway.API/Gateway.API.csproj
+++ b/api gateway/Gateway.API/Gateway.API/Gateway.API.csproj
@@ -21,6 +21,7 @@
         <ItemGroup>
                 <Protobuf Include="Protos\vehicle.proto" GrpcServices="Client" />
                 <Protobuf Include="Protos\driver.proto" GrpcServices="Client" />
+                <Protobuf Include="Protos\fuel.proto" GrpcServices="Client" />
         </ItemGroup>
 
 </Project>

--- a/api gateway/Gateway.API/Gateway.API/GrpcClients/DriverGrpcClient.cs
+++ b/api gateway/Gateway.API/Gateway.API/GrpcClients/DriverGrpcClient.cs
@@ -2,6 +2,9 @@ using Grpc.Net.Client;
 using Gateway.API.Models;
 using Google.Protobuf.WellKnownTypes;
 using DriversService;
+using DriverGrpc = DriversService.ConductorDto;
+using DriverCreateGrpc = DriversService.ConductorCreateRequest;
+using DriverUpdateGrpc = DriversService.ConductorUpdateRequest;
 
 namespace Gateway.API.GrpcClients;
 
@@ -19,12 +22,12 @@ public class DriverGrpcClient
         _client = new DriverService.DriverServiceClient(channel);
     }
 
-    public async Task<IEnumerable<ConductorDto>> GetAllAsync()
+    public async Task<IEnumerable<Models.ConductorDto>> GetAllAsync()
     {
         try
         {
             var response = await _client.ListarConductoresAsync(new Empty());
-            return response.Conductores.Select(c => new ConductorDto
+            return response.Conductores.Select(c => new Models.ConductorDto
             {
                 ConductorId = c.ConductorId,
                 Codigo = c.Codigo,
@@ -48,12 +51,12 @@ public class DriverGrpcClient
         }
     }
 
-    public async Task<ConductorDto?> GetByIdAsync(int id)
+    public async Task<Models.ConductorDto?> GetByIdAsync(int id)
     {
         try
         {
             var response = await _client.ObtenerConductorPorIdAsync(new ConductorIdRequest { ConductorId = id });
-            return new ConductorDto
+            return new Models.ConductorDto
             {
                 ConductorId = response.ConductorId,
                 Codigo = response.Codigo,
@@ -81,11 +84,11 @@ public class DriverGrpcClient
         }
     }
 
-    public async Task<ConductorDto> CreateAsync(ConductorCreateRequest request)
+    public async Task<Models.ConductorDto> CreateAsync(Models.ConductorCreateRequest request)
     {
         try
         {
-            var grpcRequest = new ConductorCreateRequest
+            var grpcRequest = new DriverCreateGrpc
             {
                 Codigo = request.Codigo,
                 Nombre = request.Nombre,
@@ -103,7 +106,7 @@ public class DriverGrpcClient
 
             var response = await _client.CrearConductorAsync(grpcRequest);
 
-            return new ConductorDto
+            return new Models.ConductorDto
             {
                 ConductorId = response.ConductorId,
                 Codigo = response.Codigo,
@@ -127,11 +130,11 @@ public class DriverGrpcClient
         }
     }
 
-    public async Task<ConductorDto> UpdateAsync(int id, ConductorUpdateRequest request)
+    public async Task<Models.ConductorDto> UpdateAsync(int id, Models.ConductorUpdateRequest request)
     {
         try
         {
-            var grpcRequest = new ConductorUpdateRequest
+            var grpcRequest = new DriverUpdateGrpc
             {
                 ConductorId = id
             };
@@ -151,7 +154,7 @@ public class DriverGrpcClient
 
             var response = await _client.EditarConductorAsync(grpcRequest);
 
-            return new ConductorDto
+            return new Models.ConductorDto
             {
                 ConductorId = response.ConductorId,
                 Codigo = response.Codigo,

--- a/api gateway/Gateway.API/Gateway.API/GrpcClients/FuelGrpcClient.cs
+++ b/api gateway/Gateway.API/Gateway.API/GrpcClients/FuelGrpcClient.cs
@@ -1,0 +1,39 @@
+using Grpc.Net.Client;
+using Gateway.API.Models;
+using Google.Protobuf.WellKnownTypes;
+using FuelService;
+using FuelRecordGrpc = FuelService.RegistroCombustibleDto;
+using FuelGrpcService = FuelService.FuelService;
+
+namespace Gateway.API.GrpcClients;
+
+public class FuelGrpcClient
+{
+    private readonly FuelGrpcService.FuelServiceClient _client;
+
+    public FuelGrpcClient(IConfiguration configuration)
+    {
+        var url = configuration["GrpcSettings:FuelService"];
+        if (string.IsNullOrWhiteSpace(url))
+            throw new InvalidOperationException("No se configuró la URL del microservicio de combustible.");
+        var channel = GrpcChannel.ForAddress(url);
+        _client = new FuelGrpcService.FuelServiceClient(channel);
+    }
+
+    public async Task<IEnumerable<Models.RegistroCombustibleDto>> GetRegistrosAsync()
+    {
+        var response = await _client.ListarRegistrosAsync(new Empty());
+        return response.Registros.Select(r => new Models.RegistroCombustibleDto
+        {
+            RegistroId = r.RegistroId,
+            Fecha = r.Fecha.ToDateTime(),
+            CodigoVehiculo = r.CodigoVehiculo,
+            CodigoConductor = r.CodigoConductor,
+            CodigoRuta = r.CodigoRuta,
+            TipoMaquinaria = r.TipoMaquinaria,
+            CantidadCombustible = r.CantidadCombustible,
+            PrecioCombustible = r.PrecioCombustible,
+            CostoTotal = r.CostoTotal
+        });
+    }
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/RegistroCombustibleDto.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/RegistroCombustibleDto.cs
@@ -1,0 +1,14 @@
+namespace Gateway.API.Models;
+
+public class RegistroCombustibleDto
+{
+    public int RegistroId { get; set; }
+    public DateTime Fecha { get; set; }
+    public string CodigoVehiculo { get; set; } = string.Empty;
+    public string CodigoConductor { get; set; } = string.Empty;
+    public string CodigoRuta { get; set; } = string.Empty;
+    public string TipoMaquinaria { get; set; } = string.Empty;
+    public double CantidadCombustible { get; set; }
+    public double PrecioCombustible { get; set; }
+    public double CostoTotal { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Program.cs
+++ b/api gateway/Gateway.API/Gateway.API/Program.cs
@@ -11,6 +11,7 @@ builder.Services.AddSwaggerGen();
 //Registro Cliente gRPC
 builder.Services.AddSingleton<VehiculoGrpcClient>();
 builder.Services.AddSingleton<DriverGrpcClient>();
+builder.Services.AddSingleton<FuelGrpcClient>();
 
 
 var app = builder.Build();

--- a/api gateway/Gateway.API/Gateway.API/Protos/fuel.proto
+++ b/api gateway/Gateway.API/Gateway.API/Protos/fuel.proto
@@ -1,0 +1,188 @@
+syntax = "proto3";
+
+option csharp_namespace = "FuelService";
+
+package fuel;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+message RegistroCombustibleDto {
+  int32 registroId = 1;
+  google.protobuf.Timestamp fecha = 2;
+  string codigoVehiculo = 3;
+  string codigoConductor = 4;
+  string codigoRuta = 5;
+  string tipoMaquinaria = 6;
+  double odometroInicial = 7;
+  double odometroFinal = 8;
+  double distancia = 9;
+  double cantidadCombustible = 10;
+  double precioCombustible = 11;
+  double costoTotal = 12;
+  double consumoReal = 13;
+  double consumoEstimado = 14;
+  double diferencia = 15;
+  string tipoCombustible = 16;
+  string numeroFactura = 17;
+  string nombreEstacionServicio = 18;
+  string comentarios = 19;
+  google.protobuf.Timestamp creadoEn = 20;
+  string creadoPor = 21;
+}
+
+message RegistroCombustibleCreateRequest {
+  google.protobuf.Timestamp fecha = 1;
+  string codigoVehiculo = 2;
+  string codigoConductor = 3;
+  string codigoRuta = 4;
+  string tipoMaquinaria = 5;
+  double odometroInicial = 6;
+  double odometroFinal = 7;
+  double distancia = 8;
+  double cantidadCombustible = 9;
+  double precioCombustible = 10;
+  double consumoEstimado = 11;
+  string tipoCombustible = 12;
+  string numeroFactura = 13;
+  string nombreEstacionServicio = 14;
+  string comentarios = 15;
+  string creadoPor = 16;
+}
+
+message RegistroCombustibleIdRequest { int32 registroId = 1; }
+
+message RegistroCombustibleUpdateRequest {
+  int32 registroId = 1;
+  optional google.protobuf.Timestamp fecha = 2;
+  optional string codigoVehiculo = 3;
+  optional string codigoConductor = 4;
+  optional string codigoRuta = 5;
+  optional string tipoMaquinaria = 6;
+  optional double odometroInicial = 7;
+  optional double odometroFinal = 8;
+  optional double distancia = 9;
+  optional double cantidadCombustible = 10;
+  optional double precioCombustible = 11;
+  optional double consumoEstimado = 12;
+  optional string tipoCombustible = 13;
+  optional string numeroFactura = 14;
+  optional string nombreEstacionServicio = 15;
+  optional string comentarios = 16;
+}
+
+message ListaRegistrosCombustible { repeated RegistroCombustibleDto registros = 1; }
+
+message ConsumoRutaDto {
+  int32 consumoId = 1;
+  string codigoRuta = 2;
+  string periodo = 3;
+  string tipoMaquinaria = 4;
+  int32 totalVehiculos = 5;
+  double distanciaTotal = 6;
+  double combustibleTotal = 7;
+  double costoTotal = 8;
+  double consumoPromedio = 9;
+  double consumoEstimado = 10;
+  double porcentajeDiferencia = 11;
+  google.protobuf.Timestamp creadoEn = 12;
+  google.protobuf.Timestamp actualizadoEn = 13;
+}
+
+message ConsumoRutaCreateRequest {
+  string codigoRuta = 1;
+  string periodo = 2;
+  string tipoMaquinaria = 3;
+  int32 totalVehiculos = 4;
+  double distanciaTotal = 5;
+  double combustibleTotal = 6;
+  double costoTotal = 7;
+  double consumoPromedio = 8;
+  double consumoEstimado = 9;
+  double porcentajeDiferencia = 10;
+}
+
+message ConsumoRutaIdRequest { int32 consumoId = 1; }
+
+message ConsumoRutaUpdateRequest {
+  int32 consumoId = 1;
+  optional string codigoRuta = 2;
+  optional string periodo = 3;
+  optional string tipoMaquinaria = 4;
+  optional int32 totalVehiculos = 5;
+  optional double distanciaTotal = 6;
+  optional double combustibleTotal = 7;
+  optional double costoTotal = 8;
+  optional double consumoPromedio = 9;
+  optional double consumoEstimado = 10;
+  optional double porcentajeDiferencia = 11;
+}
+
+message ListaConsumoRuta { repeated ConsumoRutaDto consumos = 1; }
+
+message ConsumoTipoMaquinariaDto {
+  int32 consumoMaquinariaId = 1;
+  string tipoMaquinaria = 2;
+  string periodo = 3;
+  int32 totalVehiculos = 4;
+  double distanciaTotal = 5;
+  double combustibleTotal = 6;
+  double costoTotal = 7;
+  double consumoPromedio = 8;
+  double consumoEstimado = 9;
+  double porcentajeDiferencia = 10;
+  google.protobuf.Timestamp creadoEn = 11;
+  google.protobuf.Timestamp actualizadoEn = 12;
+}
+
+message ConsumoTipoMaquinariaCreateRequest {
+  string tipoMaquinaria = 1;
+  string periodo = 2;
+  int32 totalVehiculos = 3;
+  double distanciaTotal = 4;
+  double combustibleTotal = 5;
+  double costoTotal = 6;
+  double consumoPromedio = 7;
+  double consumoEstimado = 8;
+  double porcentajeDiferencia = 9;
+}
+
+message ConsumoTipoMaquinariaIdRequest { int32 consumoMaquinariaId = 1; }
+
+message ConsumoTipoMaquinariaUpdateRequest {
+  int32 consumoMaquinariaId = 1;
+  optional string tipoMaquinaria = 2;
+  optional string periodo = 3;
+  optional int32 totalVehiculos = 4;
+  optional double distanciaTotal = 5;
+  optional double combustibleTotal = 6;
+  optional double costoTotal = 7;
+  optional double consumoPromedio = 8;
+  optional double consumoEstimado = 9;
+  optional double porcentajeDiferencia = 10;
+}
+
+message ListaConsumoTipoMaquinaria { repeated ConsumoTipoMaquinariaDto consumos = 1; }
+
+service FuelService {
+  // Registros de Combustible
+  rpc CrearRegistro (RegistroCombustibleCreateRequest) returns (RegistroCombustibleDto);
+  rpc ObtenerRegistro (RegistroCombustibleIdRequest) returns (RegistroCombustibleDto);
+  rpc ListarRegistros (google.protobuf.Empty) returns (ListaRegistrosCombustible);
+  rpc EditarRegistro (RegistroCombustibleUpdateRequest) returns (RegistroCombustibleDto);
+  rpc EliminarRegistro (RegistroCombustibleIdRequest) returns (google.protobuf.Empty);
+
+  // Consumos por Ruta
+  rpc CrearConsumoRuta (ConsumoRutaCreateRequest) returns (ConsumoRutaDto);
+  rpc ObtenerConsumoRuta (ConsumoRutaIdRequest) returns (ConsumoRutaDto);
+  rpc ListarConsumoRuta (google.protobuf.Empty) returns (ListaConsumoRuta);
+  rpc EditarConsumoRuta (ConsumoRutaUpdateRequest) returns (ConsumoRutaDto);
+  rpc EliminarConsumoRuta (ConsumoRutaIdRequest) returns (google.protobuf.Empty);
+
+  // Consumos por Tipo de Maquinaria
+  rpc CrearConsumoTipoMaquinaria (ConsumoTipoMaquinariaCreateRequest) returns (ConsumoTipoMaquinariaDto);
+  rpc ObtenerConsumoTipoMaquinaria (ConsumoTipoMaquinariaIdRequest) returns (ConsumoTipoMaquinariaDto);
+  rpc ListarConsumoTipoMaquinaria (google.protobuf.Empty) returns (ListaConsumoTipoMaquinaria);
+  rpc EditarConsumoTipoMaquinaria (ConsumoTipoMaquinariaUpdateRequest) returns (ConsumoTipoMaquinariaDto);
+  rpc EliminarConsumoTipoMaquinaria (ConsumoTipoMaquinariaIdRequest) returns (google.protobuf.Empty);
+}

--- a/api gateway/Gateway.API/Gateway.API/appsettings.json
+++ b/api gateway/Gateway.API/Gateway.API/appsettings.json
@@ -1,7 +1,8 @@
 {
     "GrpcSettings": {
         "VehiclesService": "http://localhost:5117",
-        "DriversService": "http://localhost:5120"
+        "DriversService": "http://localhost:5120",
+        "FuelService": "http://localhost:5125"
     },
     "Logging": {
         "LogLevel": {

--- a/fuel-service/.gitignore
+++ b/fuel-service/.gitignore
@@ -1,0 +1,25 @@
+# Build
+bin/
+obj/
+
+# Visual Studio
+.vs/
+*.user
+*.suo
+*.sln.docstates
+
+# Logs
+*.log
+
+# gRPC generated files
+**/obj/**/*.cs
+
+# Secrets and env
+appsettings.Development.json
+.env
+.env.local
+
+# Others
+*.dbmdl
+.DS_Store
+Thumbs.db

--- a/fuel-service/fuel-service.sln
+++ b/fuel-service/fuel-service.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fuel-service", "fuel-service\fuel-service.csproj", "{53D8CA3A-223E-4228-B756-C512A8C9E88C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{53D8CA3A-223E-4228-B756-C512A8C9E88C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53D8CA3A-223E-4228-B756-C512A8C9E88C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53D8CA3A-223E-4228-B756-C512A8C9E88C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53D8CA3A-223E-4228-B756-C512A8C9E88C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/fuel-service/fuel-service/Dockerfile
+++ b/fuel-service/fuel-service/Dockerfile
@@ -1,0 +1,24 @@
+# Build and publish
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+USER $APP_UID
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["fuel-service/fuel-service.csproj", "fuel-service/"]
+RUN dotnet restore "fuel-service/fuel-service.csproj"
+COPY . .
+WORKDIR "/src/fuel-service"
+RUN dotnet build "fuel-service.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "fuel-service.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "fuel-service.dll"]

--- a/fuel-service/fuel-service/Domain/Entities/ConsumoCombustibleRuta.cs
+++ b/fuel-service/fuel-service/Domain/Entities/ConsumoCombustibleRuta.cs
@@ -1,0 +1,18 @@
+namespace FuelService.Domain.Entities;
+
+public class ConsumoCombustibleRuta
+{
+    public int ConsumoId { get; set; }
+    public required string CodigoRuta { get; set; }
+    public required string Periodo { get; set; }
+    public required string TipoMaquinaria { get; set; }
+    public int TotalVehiculos { get; set; }
+    public decimal DistanciaTotal { get; set; }
+    public decimal CombustibleTotal { get; set; }
+    public decimal CostoTotal { get; set; }
+    public decimal ConsumoPromedio { get; set; }
+    public decimal ConsumoEstimado { get; set; }
+    public decimal PorcentajeDiferencia { get; set; }
+    public DateTime CreadoEn { get; set; }
+    public DateTime? ActualizadoEn { get; set; }
+}

--- a/fuel-service/fuel-service/Domain/Entities/ConsumoCombustibleTipoMaquinaria.cs
+++ b/fuel-service/fuel-service/Domain/Entities/ConsumoCombustibleTipoMaquinaria.cs
@@ -1,0 +1,17 @@
+namespace FuelService.Domain.Entities;
+
+public class ConsumoCombustibleTipoMaquinaria
+{
+    public int ConsumoMaquinariaId { get; set; }
+    public required string TipoMaquinaria { get; set; }
+    public required string Periodo { get; set; }
+    public int TotalVehiculos { get; set; }
+    public decimal DistanciaTotal { get; set; }
+    public decimal CombustibleTotal { get; set; }
+    public decimal CostoTotal { get; set; }
+    public decimal ConsumoPromedio { get; set; }
+    public decimal ConsumoEstimado { get; set; }
+    public decimal PorcentajeDiferencia { get; set; }
+    public DateTime CreadoEn { get; set; }
+    public DateTime? ActualizadoEn { get; set; }
+}

--- a/fuel-service/fuel-service/Domain/Entities/RegistroCombustible.cs
+++ b/fuel-service/fuel-service/Domain/Entities/RegistroCombustible.cs
@@ -1,0 +1,26 @@
+namespace FuelService.Domain.Entities;
+
+public class RegistroCombustible
+{
+    public int RegistroId { get; set; }
+    public DateTime Fecha { get; set; }
+    public required string CodigoVehiculo { get; set; }
+    public required string CodigoConductor { get; set; }
+    public required string CodigoRuta { get; set; }
+    public required string TipoMaquinaria { get; set; }
+    public decimal OdometroInicial { get; set; }
+    public decimal OdometroFinal { get; set; }
+    public decimal Distancia { get; set; }
+    public decimal CantidadCombustible { get; set; }
+    public decimal PrecioCombustible { get; set; }
+    public decimal CostoTotal { get; set; }
+    public decimal ConsumoReal { get; set; }
+    public decimal ConsumoEstimado { get; set; }
+    public decimal Diferencia { get; set; }
+    public required string TipoCombustible { get; set; }
+    public string? NumeroFactura { get; set; }
+    public string? NombreEstacionServicio { get; set; }
+    public string? Comentarios { get; set; }
+    public DateTime CreadoEn { get; set; }
+    public required string CreadoPor { get; set; }
+}

--- a/fuel-service/fuel-service/Persistence/FuelDbContext.cs
+++ b/fuel-service/fuel-service/Persistence/FuelDbContext.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore;
+using FuelService.Domain.Entities;
+
+namespace FuelService.Persistence;
+
+public class FuelDbContext : DbContext
+{
+    public FuelDbContext(DbContextOptions<FuelDbContext> options) : base(options) { }
+
+    public DbSet<RegistroCombustible> RegistrosCombustible => Set<RegistroCombustible>();
+    public DbSet<ConsumoCombustibleRuta> ConsumosRuta => Set<ConsumoCombustibleRuta>();
+    public DbSet<ConsumoCombustibleTipoMaquinaria> ConsumosTipoMaquinaria => Set<ConsumoCombustibleTipoMaquinaria>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<RegistroCombustible>().ToTable("registros_combustible");
+        modelBuilder.Entity<ConsumoCombustibleRuta>().ToTable("consumo_combustible_ruta");
+        modelBuilder.Entity<ConsumoCombustibleTipoMaquinaria>().ToTable("consumo_combustible_tipo_maquinaria");
+
+        var registro = modelBuilder.Entity<RegistroCombustible>();
+        registro.HasKey(r => r.RegistroId);
+        registro.Property(r => r.RegistroId).HasColumnName("registro_id");
+        registro.Property(r => r.Fecha).HasColumnName("fecha");
+        registro.Property(r => r.CodigoVehiculo).HasColumnName("codigo_vehiculo");
+        registro.Property(r => r.CodigoConductor).HasColumnName("codigo_conductor");
+        registro.Property(r => r.CodigoRuta).HasColumnName("codigo_ruta");
+        registro.Property(r => r.TipoMaquinaria).HasColumnName("tipo_maquinaria");
+        registro.Property(r => r.OdometroInicial).HasColumnName("odometro_inicial");
+        registro.Property(r => r.OdometroFinal).HasColumnName("odometro_final");
+        registro.Property(r => r.Distancia).HasColumnName("distancia");
+        registro.Property(r => r.CantidadCombustible).HasColumnName("cantidad_combustible");
+        registro.Property(r => r.PrecioCombustible).HasColumnName("precio_combustible");
+        registro.Property(r => r.CostoTotal).HasColumnName("costo_total");
+        registro.Property(r => r.ConsumoReal).HasColumnName("consumo_real");
+        registro.Property(r => r.ConsumoEstimado).HasColumnName("consumo_estimado");
+        registro.Property(r => r.Diferencia).HasColumnName("diferencia");
+        registro.Property(r => r.TipoCombustible).HasColumnName("tipo_combustible");
+        registro.Property(r => r.NumeroFactura).HasColumnName("numero_factura");
+        registro.Property(r => r.NombreEstacionServicio).HasColumnName("nombre_estacion_servicio");
+        registro.Property(r => r.Comentarios).HasColumnName("comentarios");
+        registro.Property(r => r.CreadoEn).HasColumnName("creado_en");
+        registro.Property(r => r.CreadoPor).HasColumnName("creado_por");
+
+        var ruta = modelBuilder.Entity<ConsumoCombustibleRuta>();
+        ruta.HasKey(r => r.ConsumoId);
+        ruta.Property(r => r.ConsumoId).HasColumnName("consumo_id");
+        ruta.Property(r => r.CodigoRuta).HasColumnName("codigo_ruta");
+        ruta.Property(r => r.Periodo).HasColumnName("periodo");
+        ruta.Property(r => r.TipoMaquinaria).HasColumnName("tipo_maquinaria");
+        ruta.Property(r => r.TotalVehiculos).HasColumnName("total_vehiculos");
+        ruta.Property(r => r.DistanciaTotal).HasColumnName("distancia_total");
+        ruta.Property(r => r.CombustibleTotal).HasColumnName("combustible_total");
+        ruta.Property(r => r.CostoTotal).HasColumnName("costo_total");
+        ruta.Property(r => r.ConsumoPromedio).HasColumnName("consumo_promedio");
+        ruta.Property(r => r.ConsumoEstimado).HasColumnName("consumo_estimado");
+        ruta.Property(r => r.PorcentajeDiferencia).HasColumnName("porcentaje_diferencia");
+        ruta.Property(r => r.CreadoEn).HasColumnName("creado_en");
+        ruta.Property(r => r.ActualizadoEn).HasColumnName("actualizado_en");
+
+        var maq = modelBuilder.Entity<ConsumoCombustibleTipoMaquinaria>();
+        maq.HasKey(m => m.ConsumoMaquinariaId);
+        maq.Property(m => m.ConsumoMaquinariaId).HasColumnName("consumo_maquinaria_id");
+        maq.Property(m => m.TipoMaquinaria).HasColumnName("tipo_maquinaria");
+        maq.Property(m => m.Periodo).HasColumnName("periodo");
+        maq.Property(m => m.TotalVehiculos).HasColumnName("total_vehiculos");
+        maq.Property(m => m.DistanciaTotal).HasColumnName("distancia_total");
+        maq.Property(m => m.CombustibleTotal).HasColumnName("combustible_total");
+        maq.Property(m => m.CostoTotal).HasColumnName("costo_total");
+        maq.Property(m => m.ConsumoPromedio).HasColumnName("consumo_promedio");
+        maq.Property(m => m.ConsumoEstimado).HasColumnName("consumo_estimado");
+        maq.Property(m => m.PorcentajeDiferencia).HasColumnName("porcentaje_diferencia");
+        maq.Property(m => m.CreadoEn).HasColumnName("creado_en");
+        maq.Property(m => m.ActualizadoEn).HasColumnName("actualizado_en");
+    }
+}

--- a/fuel-service/fuel-service/Program.cs
+++ b/fuel-service/fuel-service/Program.cs
@@ -1,0 +1,16 @@
+using FuelService.Persistence;
+using FuelService.Services;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddGrpc();
+builder.Services.AddDbContext<FuelDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+var app = builder.Build();
+
+app.MapGrpcService<FuelGrpcService>();
+app.MapGet("/", () => "gRPC service for fuel management");
+
+app.Run();

--- a/fuel-service/fuel-service/Properties/launchSettings.json
+++ b/fuel-service/fuel-service/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5210",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7192;http://localhost:5210",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/fuel-service/fuel-service/Protos/fuel.proto
+++ b/fuel-service/fuel-service/Protos/fuel.proto
@@ -1,0 +1,188 @@
+syntax = "proto3";
+
+option csharp_namespace = "FuelService";
+
+package fuel;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+message RegistroCombustibleDto {
+  int32 registroId = 1;
+  google.protobuf.Timestamp fecha = 2;
+  string codigoVehiculo = 3;
+  string codigoConductor = 4;
+  string codigoRuta = 5;
+  string tipoMaquinaria = 6;
+  double odometroInicial = 7;
+  double odometroFinal = 8;
+  double distancia = 9;
+  double cantidadCombustible = 10;
+  double precioCombustible = 11;
+  double costoTotal = 12;
+  double consumoReal = 13;
+  double consumoEstimado = 14;
+  double diferencia = 15;
+  string tipoCombustible = 16;
+  string numeroFactura = 17;
+  string nombreEstacionServicio = 18;
+  string comentarios = 19;
+  google.protobuf.Timestamp creadoEn = 20;
+  string creadoPor = 21;
+}
+
+message RegistroCombustibleCreateRequest {
+  google.protobuf.Timestamp fecha = 1;
+  string codigoVehiculo = 2;
+  string codigoConductor = 3;
+  string codigoRuta = 4;
+  string tipoMaquinaria = 5;
+  double odometroInicial = 6;
+  double odometroFinal = 7;
+  double distancia = 8;
+  double cantidadCombustible = 9;
+  double precioCombustible = 10;
+  double consumoEstimado = 11;
+  string tipoCombustible = 12;
+  string numeroFactura = 13;
+  string nombreEstacionServicio = 14;
+  string comentarios = 15;
+  string creadoPor = 16;
+}
+
+message RegistroCombustibleIdRequest { int32 registroId = 1; }
+
+message RegistroCombustibleUpdateRequest {
+  int32 registroId = 1;
+  optional google.protobuf.Timestamp fecha = 2;
+  optional string codigoVehiculo = 3;
+  optional string codigoConductor = 4;
+  optional string codigoRuta = 5;
+  optional string tipoMaquinaria = 6;
+  optional double odometroInicial = 7;
+  optional double odometroFinal = 8;
+  optional double distancia = 9;
+  optional double cantidadCombustible = 10;
+  optional double precioCombustible = 11;
+  optional double consumoEstimado = 12;
+  optional string tipoCombustible = 13;
+  optional string numeroFactura = 14;
+  optional string nombreEstacionServicio = 15;
+  optional string comentarios = 16;
+}
+
+message ListaRegistrosCombustible { repeated RegistroCombustibleDto registros = 1; }
+
+message ConsumoRutaDto {
+  int32 consumoId = 1;
+  string codigoRuta = 2;
+  string periodo = 3;
+  string tipoMaquinaria = 4;
+  int32 totalVehiculos = 5;
+  double distanciaTotal = 6;
+  double combustibleTotal = 7;
+  double costoTotal = 8;
+  double consumoPromedio = 9;
+  double consumoEstimado = 10;
+  double porcentajeDiferencia = 11;
+  google.protobuf.Timestamp creadoEn = 12;
+  google.protobuf.Timestamp actualizadoEn = 13;
+}
+
+message ConsumoRutaCreateRequest {
+  string codigoRuta = 1;
+  string periodo = 2;
+  string tipoMaquinaria = 3;
+  int32 totalVehiculos = 4;
+  double distanciaTotal = 5;
+  double combustibleTotal = 6;
+  double costoTotal = 7;
+  double consumoPromedio = 8;
+  double consumoEstimado = 9;
+  double porcentajeDiferencia = 10;
+}
+
+message ConsumoRutaIdRequest { int32 consumoId = 1; }
+
+message ConsumoRutaUpdateRequest {
+  int32 consumoId = 1;
+  optional string codigoRuta = 2;
+  optional string periodo = 3;
+  optional string tipoMaquinaria = 4;
+  optional int32 totalVehiculos = 5;
+  optional double distanciaTotal = 6;
+  optional double combustibleTotal = 7;
+  optional double costoTotal = 8;
+  optional double consumoPromedio = 9;
+  optional double consumoEstimado = 10;
+  optional double porcentajeDiferencia = 11;
+}
+
+message ListaConsumoRuta { repeated ConsumoRutaDto consumos = 1; }
+
+message ConsumoTipoMaquinariaDto {
+  int32 consumoMaquinariaId = 1;
+  string tipoMaquinaria = 2;
+  string periodo = 3;
+  int32 totalVehiculos = 4;
+  double distanciaTotal = 5;
+  double combustibleTotal = 6;
+  double costoTotal = 7;
+  double consumoPromedio = 8;
+  double consumoEstimado = 9;
+  double porcentajeDiferencia = 10;
+  google.protobuf.Timestamp creadoEn = 11;
+  google.protobuf.Timestamp actualizadoEn = 12;
+}
+
+message ConsumoTipoMaquinariaCreateRequest {
+  string tipoMaquinaria = 1;
+  string periodo = 2;
+  int32 totalVehiculos = 3;
+  double distanciaTotal = 4;
+  double combustibleTotal = 5;
+  double costoTotal = 6;
+  double consumoPromedio = 7;
+  double consumoEstimado = 8;
+  double porcentajeDiferencia = 9;
+}
+
+message ConsumoTipoMaquinariaIdRequest { int32 consumoMaquinariaId = 1; }
+
+message ConsumoTipoMaquinariaUpdateRequest {
+  int32 consumoMaquinariaId = 1;
+  optional string tipoMaquinaria = 2;
+  optional string periodo = 3;
+  optional int32 totalVehiculos = 4;
+  optional double distanciaTotal = 5;
+  optional double combustibleTotal = 6;
+  optional double costoTotal = 7;
+  optional double consumoPromedio = 8;
+  optional double consumoEstimado = 9;
+  optional double porcentajeDiferencia = 10;
+}
+
+message ListaConsumoTipoMaquinaria { repeated ConsumoTipoMaquinariaDto consumos = 1; }
+
+service FuelService {
+  // Registros de Combustible
+  rpc CrearRegistro (RegistroCombustibleCreateRequest) returns (RegistroCombustibleDto);
+  rpc ObtenerRegistro (RegistroCombustibleIdRequest) returns (RegistroCombustibleDto);
+  rpc ListarRegistros (google.protobuf.Empty) returns (ListaRegistrosCombustible);
+  rpc EditarRegistro (RegistroCombustibleUpdateRequest) returns (RegistroCombustibleDto);
+  rpc EliminarRegistro (RegistroCombustibleIdRequest) returns (google.protobuf.Empty);
+
+  // Consumos por Ruta
+  rpc CrearConsumoRuta (ConsumoRutaCreateRequest) returns (ConsumoRutaDto);
+  rpc ObtenerConsumoRuta (ConsumoRutaIdRequest) returns (ConsumoRutaDto);
+  rpc ListarConsumoRuta (google.protobuf.Empty) returns (ListaConsumoRuta);
+  rpc EditarConsumoRuta (ConsumoRutaUpdateRequest) returns (ConsumoRutaDto);
+  rpc EliminarConsumoRuta (ConsumoRutaIdRequest) returns (google.protobuf.Empty);
+
+  // Consumos por Tipo de Maquinaria
+  rpc CrearConsumoTipoMaquinaria (ConsumoTipoMaquinariaCreateRequest) returns (ConsumoTipoMaquinariaDto);
+  rpc ObtenerConsumoTipoMaquinaria (ConsumoTipoMaquinariaIdRequest) returns (ConsumoTipoMaquinariaDto);
+  rpc ListarConsumoTipoMaquinaria (google.protobuf.Empty) returns (ListaConsumoTipoMaquinaria);
+  rpc EditarConsumoTipoMaquinaria (ConsumoTipoMaquinariaUpdateRequest) returns (ConsumoTipoMaquinariaDto);
+  rpc EliminarConsumoTipoMaquinaria (ConsumoTipoMaquinariaIdRequest) returns (google.protobuf.Empty);
+}

--- a/fuel-service/fuel-service/Services/FuelGrpcService.cs
+++ b/fuel-service/fuel-service/Services/FuelGrpcService.cs
@@ -1,0 +1,297 @@
+using FuelService.Domain.Entities;
+using FuelService.Persistence;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Microsoft.EntityFrameworkCore;
+
+namespace FuelService.Services;
+
+public class FuelGrpcService : FuelService.FuelServiceBase
+{
+    private readonly FuelDbContext _context;
+
+    public FuelGrpcService(FuelDbContext context)
+    {
+        _context = context;
+    }
+
+    // Helpers
+    private static RegistroCombustibleDto ToDto(RegistroCombustible r) => new()
+    {
+        RegistroId = r.RegistroId,
+        Fecha = Timestamp.FromDateTime(r.Fecha.ToUniversalTime()),
+        CodigoVehiculo = r.CodigoVehiculo,
+        CodigoConductor = r.CodigoConductor,
+        CodigoRuta = r.CodigoRuta,
+        TipoMaquinaria = r.TipoMaquinaria,
+        OdometroInicial = (double)r.OdometroInicial,
+        OdometroFinal = (double)r.OdometroFinal,
+        Distancia = (double)r.Distancia,
+        CantidadCombustible = (double)r.CantidadCombustible,
+        PrecioCombustible = (double)r.PrecioCombustible,
+        CostoTotal = (double)r.CostoTotal,
+        ConsumoReal = (double)r.ConsumoReal,
+        ConsumoEstimado = (double)r.ConsumoEstimado,
+        Diferencia = (double)r.Diferencia,
+        TipoCombustible = r.TipoCombustible,
+        NumeroFactura = r.NumeroFactura ?? string.Empty,
+        NombreEstacionServicio = r.NombreEstacionServicio ?? string.Empty,
+        Comentarios = r.Comentarios ?? string.Empty,
+        CreadoEn = Timestamp.FromDateTime(r.CreadoEn.ToUniversalTime()),
+        CreadoPor = r.CreadoPor
+    };
+
+    private static ConsumoRutaDto ToDto(ConsumoCombustibleRuta c) => new()
+    {
+        ConsumoId = c.ConsumoId,
+        CodigoRuta = c.CodigoRuta,
+        Periodo = c.Periodo,
+        TipoMaquinaria = c.TipoMaquinaria,
+        TotalVehiculos = c.TotalVehiculos,
+        DistanciaTotal = (double)c.DistanciaTotal,
+        CombustibleTotal = (double)c.CombustibleTotal,
+        CostoTotal = (double)c.CostoTotal,
+        ConsumoPromedio = (double)c.ConsumoPromedio,
+        ConsumoEstimado = (double)c.ConsumoEstimado,
+        PorcentajeDiferencia = (double)c.PorcentajeDiferencia,
+        CreadoEn = Timestamp.FromDateTime(c.CreadoEn.ToUniversalTime()),
+        ActualizadoEn = c.ActualizadoEn != null ? Timestamp.FromDateTime(c.ActualizadoEn.Value.ToUniversalTime()) : null
+    };
+
+    private static ConsumoTipoMaquinariaDto ToDto(ConsumoCombustibleTipoMaquinaria c) => new()
+    {
+        ConsumoMaquinariaId = c.ConsumoMaquinariaId,
+        TipoMaquinaria = c.TipoMaquinaria,
+        Periodo = c.Periodo,
+        TotalVehiculos = c.TotalVehiculos,
+        DistanciaTotal = (double)c.DistanciaTotal,
+        CombustibleTotal = (double)c.CombustibleTotal,
+        CostoTotal = (double)c.CostoTotal,
+        ConsumoPromedio = (double)c.ConsumoPromedio,
+        ConsumoEstimado = (double)c.ConsumoEstimado,
+        PorcentajeDiferencia = (double)c.PorcentajeDiferencia,
+        CreadoEn = Timestamp.FromDateTime(c.CreadoEn.ToUniversalTime()),
+        ActualizadoEn = c.ActualizadoEn != null ? Timestamp.FromDateTime(c.ActualizadoEn.Value.ToUniversalTime()) : null
+    };
+
+    // Registros CRUD
+    public override async Task<RegistroCombustibleDto> CrearRegistro(RegistroCombustibleCreateRequest request, ServerCallContext context)
+    {
+        var entity = new RegistroCombustible
+        {
+            Fecha = request.Fecha.ToDateTime(),
+            CodigoVehiculo = request.CodigoVehiculo,
+            CodigoConductor = request.CodigoConductor,
+            CodigoRuta = request.CodigoRuta,
+            TipoMaquinaria = request.TipoMaquinaria,
+            OdometroInicial = (decimal)request.OdometroInicial,
+            OdometroFinal = (decimal)request.OdometroFinal,
+            Distancia = (decimal)request.Distancia,
+            CantidadCombustible = (decimal)request.CantidadCombustible,
+            PrecioCombustible = (decimal)request.PrecioCombustible,
+            ConsumoEstimado = (decimal)request.ConsumoEstimado,
+            TipoCombustible = request.TipoCombustible,
+            NumeroFactura = request.NumeroFactura,
+            NombreEstacionServicio = request.NombreEstacionServicio,
+            Comentarios = request.Comentarios,
+            CreadoEn = DateTime.UtcNow,
+            CreadoPor = request.CreadoPor,
+            CostoTotal = (decimal)request.CantidadCombustible * (decimal)request.PrecioCombustible,
+            ConsumoReal = 0,
+            Diferencia = 0
+        };
+        _context.RegistrosCombustible.Add(entity);
+        await _context.SaveChangesAsync();
+        return ToDto(entity);
+    }
+
+    public override async Task<RegistroCombustibleDto> ObtenerRegistro(RegistroCombustibleIdRequest request, ServerCallContext context)
+    {
+        var entity = await _context.RegistrosCombustible.FindAsync(request.RegistroId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Registro no encontrado"));
+        return ToDto(entity);
+    }
+
+    public override async Task<ListaRegistrosCombustible> ListarRegistros(Empty request, ServerCallContext context)
+    {
+        var list = await _context.RegistrosCombustible.ToListAsync();
+        var res = new ListaRegistrosCombustible();
+        res.Registros.AddRange(list.Select(ToDto));
+        return res;
+    }
+    public override async Task<RegistroCombustibleDto> EditarRegistro(RegistroCombustibleUpdateRequest request, ServerCallContext context)
+    {
+        var entity = await _context.RegistrosCombustible.FindAsync(request.RegistroId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Registro no encontrado"));
+
+        if (request.Fecha != null) entity.Fecha = request.Fecha.ToDateTime();
+        if (request.HasCodigoVehiculo) entity.CodigoVehiculo = request.CodigoVehiculo;
+        if (request.HasCodigoConductor) entity.CodigoConductor = request.CodigoConductor;
+        if (request.HasCodigoRuta) entity.CodigoRuta = request.CodigoRuta;
+        if (request.HasTipoMaquinaria) entity.TipoMaquinaria = request.TipoMaquinaria;
+        if (request.HasOdometroInicial) entity.OdometroInicial = (decimal)request.OdometroInicial;
+        if (request.HasOdometroFinal) entity.OdometroFinal = (decimal)request.OdometroFinal;
+        if (request.HasDistancia) entity.Distancia = (decimal)request.Distancia;
+        if (request.HasCantidadCombustible) entity.CantidadCombustible = (decimal)request.CantidadCombustible;
+        if (request.HasPrecioCombustible) entity.PrecioCombustible = (decimal)request.PrecioCombustible;
+        if (request.HasConsumoEstimado) entity.ConsumoEstimado = (decimal)request.ConsumoEstimado;
+        if (request.HasTipoCombustible) entity.TipoCombustible = request.TipoCombustible;
+        if (request.HasNumeroFactura) entity.NumeroFactura = request.NumeroFactura;
+        if (request.HasNombreEstacionServicio) entity.NombreEstacionServicio = request.NombreEstacionServicio;
+        if (request.HasComentarios) entity.Comentarios = request.Comentarios;
+
+        entity.CostoTotal = entity.CantidadCombustible * entity.PrecioCombustible;
+        await _context.SaveChangesAsync();
+        return ToDto(entity);
+    }
+
+    public override async Task<Empty> EliminarRegistro(RegistroCombustibleIdRequest request, ServerCallContext context)
+    {
+        var entity = await _context.RegistrosCombustible.FindAsync(request.RegistroId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Registro no encontrado"));
+        _context.RegistrosCombustible.Remove(entity);
+        await _context.SaveChangesAsync();
+        return new Empty();
+    }
+
+    // Consumo Ruta CRUD
+    public override async Task<ConsumoRutaDto> CrearConsumoRuta(ConsumoRutaCreateRequest request, ServerCallContext context)
+    {
+        var entity = new ConsumoCombustibleRuta
+        {
+            CodigoRuta = request.CodigoRuta,
+            Periodo = request.Periodo,
+            TipoMaquinaria = request.TipoMaquinaria,
+            TotalVehiculos = request.TotalVehiculos,
+            DistanciaTotal = (decimal)request.DistanciaTotal,
+            CombustibleTotal = (decimal)request.CombustibleTotal,
+            CostoTotal = (decimal)request.CostoTotal,
+            ConsumoPromedio = (decimal)request.ConsumoPromedio,
+            ConsumoEstimado = (decimal)request.ConsumoEstimado,
+            PorcentajeDiferencia = (decimal)request.PorcentajeDiferencia,
+            CreadoEn = DateTime.UtcNow
+        };
+        _context.ConsumosRuta.Add(entity);
+        await _context.SaveChangesAsync();
+        return ToDto(entity);
+    }
+
+    public override async Task<ConsumoRutaDto> ObtenerConsumoRuta(ConsumoRutaIdRequest request, ServerCallContext context)
+    {
+        var entity = await _context.ConsumosRuta.FindAsync(request.ConsumoId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Consumo no encontrado"));
+        return ToDto(entity);
+    }
+
+    public override async Task<ListaConsumoRuta> ListarConsumoRuta(Empty request, ServerCallContext context)
+    {
+        var list = await _context.ConsumosRuta.ToListAsync();
+        var res = new ListaConsumoRuta();
+        res.Consumos.AddRange(list.Select(ToDto));
+        return res;
+    }
+
+    public override async Task<ConsumoRutaDto> EditarConsumoRuta(ConsumoRutaUpdateRequest request, ServerCallContext context)
+    {
+        var entity = await _context.ConsumosRuta.FindAsync(request.ConsumoId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Consumo no encontrado"));
+
+        if (request.HasCodigoRuta) entity.CodigoRuta = request.CodigoRuta;
+        if (request.HasPeriodo) entity.Periodo = request.Periodo;
+        if (request.HasTipoMaquinaria) entity.TipoMaquinaria = request.TipoMaquinaria;
+        if (request.HasTotalVehiculos) entity.TotalVehiculos = request.TotalVehiculos;
+        if (request.HasDistanciaTotal) entity.DistanciaTotal = (decimal)request.DistanciaTotal;
+        if (request.HasCombustibleTotal) entity.CombustibleTotal = (decimal)request.CombustibleTotal;
+        if (request.HasCostoTotal) entity.CostoTotal = (decimal)request.CostoTotal;
+        if (request.HasConsumoPromedio) entity.ConsumoPromedio = (decimal)request.ConsumoPromedio;
+        if (request.HasConsumoEstimado) entity.ConsumoEstimado = (decimal)request.ConsumoEstimado;
+        if (request.HasPorcentajeDiferencia) entity.PorcentajeDiferencia = (decimal)request.PorcentajeDiferencia;
+        entity.ActualizadoEn = DateTime.UtcNow;
+
+        await _context.SaveChangesAsync();
+        return ToDto(entity);
+    }
+
+    public override async Task<Empty> EliminarConsumoRuta(ConsumoRutaIdRequest request, ServerCallContext context)
+    {
+        var entity = await _context.ConsumosRuta.FindAsync(request.ConsumoId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Consumo no encontrado"));
+        _context.ConsumosRuta.Remove(entity);
+        await _context.SaveChangesAsync();
+        return new Empty();
+    }
+
+    // Consumo Tipo Maquinaria CRUD
+    public override async Task<ConsumoTipoMaquinariaDto> CrearConsumoTipoMaquinaria(ConsumoTipoMaquinariaCreateRequest request, ServerCallContext context)
+    {
+        var entity = new ConsumoCombustibleTipoMaquinaria
+        {
+            TipoMaquinaria = request.TipoMaquinaria,
+            Periodo = request.Periodo,
+            TotalVehiculos = request.TotalVehiculos,
+            DistanciaTotal = (decimal)request.DistanciaTotal,
+            CombustibleTotal = (decimal)request.CombustibleTotal,
+            CostoTotal = (decimal)request.CostoTotal,
+            ConsumoPromedio = (decimal)request.ConsumoPromedio,
+            ConsumoEstimado = (decimal)request.ConsumoEstimado,
+            PorcentajeDiferencia = (decimal)request.PorcentajeDiferencia,
+            CreadoEn = DateTime.UtcNow
+        };
+        _context.ConsumosTipoMaquinaria.Add(entity);
+        await _context.SaveChangesAsync();
+        return ToDto(entity);
+    }
+
+    public override async Task<ConsumoTipoMaquinariaDto> ObtenerConsumoTipoMaquinaria(ConsumoTipoMaquinariaIdRequest request, ServerCallContext context)
+    {
+        var entity = await _context.ConsumosTipoMaquinaria.FindAsync(request.ConsumoMaquinariaId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Consumo no encontrado"));
+        return ToDto(entity);
+    }
+
+    public override async Task<ListaConsumoTipoMaquinaria> ListarConsumoTipoMaquinaria(Empty request, ServerCallContext context)
+    {
+        var list = await _context.ConsumosTipoMaquinaria.ToListAsync();
+        var res = new ListaConsumoTipoMaquinaria();
+        res.Consumos.AddRange(list.Select(ToDto));
+        return res;
+    }
+
+    public override async Task<ConsumoTipoMaquinariaDto> EditarConsumoTipoMaquinaria(ConsumoTipoMaquinariaUpdateRequest request, ServerCallContext context)
+    {
+        var entity = await _context.ConsumosTipoMaquinaria.FindAsync(request.ConsumoMaquinariaId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Consumo no encontrado"));
+
+        if (request.HasTipoMaquinaria) entity.TipoMaquinaria = request.TipoMaquinaria;
+        if (request.HasPeriodo) entity.Periodo = request.Periodo;
+        if (request.HasTotalVehiculos) entity.TotalVehiculos = request.TotalVehiculos;
+        if (request.HasDistanciaTotal) entity.DistanciaTotal = (decimal)request.DistanciaTotal;
+        if (request.HasCombustibleTotal) entity.CombustibleTotal = (decimal)request.CombustibleTotal;
+        if (request.HasCostoTotal) entity.CostoTotal = (decimal)request.CostoTotal;
+        if (request.HasConsumoPromedio) entity.ConsumoPromedio = (decimal)request.ConsumoPromedio;
+        if (request.HasConsumoEstimado) entity.ConsumoEstimado = (decimal)request.ConsumoEstimado;
+        if (request.HasPorcentajeDiferencia) entity.PorcentajeDiferencia = (decimal)request.PorcentajeDiferencia;
+        entity.ActualizadoEn = DateTime.UtcNow;
+
+        await _context.SaveChangesAsync();
+        return ToDto(entity);
+    }
+
+    public override async Task<Empty> EliminarConsumoTipoMaquinaria(ConsumoTipoMaquinariaIdRequest request, ServerCallContext context)
+    {
+        var entity = await _context.ConsumosTipoMaquinaria.FindAsync(request.ConsumoMaquinariaId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Consumo no encontrado"));
+        _context.ConsumosTipoMaquinaria.Remove(entity);
+        await _context.SaveChangesAsync();
+        return new Empty();
+    }
+}

--- a/fuel-service/fuel-service/appsettings.Development.json
+++ b/fuel-service/fuel-service/appsettings.Development.json
@@ -1,0 +1,17 @@
+{
+    "ConnectionStrings": {
+        "DefaultConnection": "Server=localhost;Database=fuel_db;Trusted_Connection=True;TrustServerCertificate=True;"
+    },
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*",
+    "Kestrel": {
+        "EndpointDefaults": {
+            "Protocols": "Http2"
+        }
+    }
+}

--- a/fuel-service/fuel-service/appsettings.json
+++ b/fuel-service/fuel-service/appsettings.json
@@ -1,0 +1,17 @@
+{
+    "ConnectionStrings": {
+        "DefaultConnection": "Server=localhost;Database=fuel_db;Trusted_Connection=True;TrustServerCertificate=True;"
+    },
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*",
+    "Kestrel": {
+        "EndpointDefaults": {
+            "Protocols": "Http2"
+        }
+    }
+}

--- a/fuel-service/fuel-service/fuel-service.csproj
+++ b/fuel-service/fuel-service/fuel-service.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\fuel.proto" GrpcServices="Server" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Grpc.Tools" Version="2.71.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Google.Protobuf" Version="3.30.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add new `fuel-service` .NET microservice with CRUD and gRPC endpoints
- expose fuel microservice via Dockerfile
- register `FuelGrpcClient` in API Gateway and add corresponding proto and model
- configure gateway to connect to the fuel service

## Testing
- `dotnet build fuel-service.sln -c Release`
- `dotnet build Gateway.API.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6863061965548333916d7afc42c4170a