### PR TITLE
Add alerts microservice and gateway integration

### DIFF
--- a/alerts-service/README.md
+++ b/alerts-service/README.md
@@ -1,0 +1,3 @@
+# Alerts Service
+
+Microservicio gRPC para gestionar alertas de consumo.

--- a/alerts-service/alerts-service.sln
+++ b/alerts-service/alerts-service.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35913.81 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "alerts-service", "alerts-service\alerts-service.csproj", "{e7fd908a-4583-43a8-8178-e7d83a31dd5c}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{e7fd908a-4583-43a8-8178-e7d83a31dd5c}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{e7fd908a-4583-43a8-8178-e7d83a31dd5c}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{e7fd908a-4583-43a8-8178-e7d83a31dd5c}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{e7fd908a-4583-43a8-8178-e7d83a31dd5c}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+GlobalSection(ExtensibilityGlobals) = postSolution
+SolutionGuid = {54bbfce2-c98e-4b9f-a678-49c55e32a9dc}
+EndGlobalSection
+EndGlobal

--- a/alerts-service/alerts-service/Dockerfile
+++ b/alerts-service/alerts-service/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+USER $APP_UID
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["alerts-service.csproj", "."]
+RUN dotnet restore "./alerts-service.csproj"
+COPY . .
+RUN dotnet build "./alerts-service.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "./alerts-service.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "alerts-service.dll"]

--- a/alerts-service/alerts-service/Domain/Entities/AlertaConsumo.cs
+++ b/alerts-service/alerts-service/Domain/Entities/AlertaConsumo.cs
@@ -1,0 +1,18 @@
+namespace AlertsService.Domain.Entities;
+
+public class AlertaConsumo
+{
+    public int AlertaId { get; set; }
+    public required string CodigoVehiculo { get; set; }
+    public required string CodigoConductor { get; set; }
+    public required string CodigoRuta { get; set; }
+    public int RegistroId { get; set; }
+    public required string TipoMaquinaria { get; set; }
+    public required string TipoAlerta { get; set; }
+    public decimal PorcentajeDiferencia { get; set; }
+    public bool Estado { get; set; }
+    public string? Descripcion { get; set; }
+    public DateTime CreadoEn { get; set; }
+    public DateTime? RevisadoEn { get; set; }
+    public string? RevisadoPor { get; set; }
+}

--- a/alerts-service/alerts-service/Persistence/AlertsDbContext.cs
+++ b/alerts-service/alerts-service/Persistence/AlertsDbContext.cs
@@ -1,0 +1,32 @@
+using AlertsService.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace AlertsService.Persistence;
+
+public class AlertsDbContext : DbContext
+{
+    public AlertsDbContext(DbContextOptions<AlertsDbContext> options) : base(options) { }
+
+    public DbSet<AlertaConsumo> AlertasConsumo => Set<AlertaConsumo>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<AlertaConsumo>().ToTable("alertas_consumo");
+
+        var alerta = modelBuilder.Entity<AlertaConsumo>();
+        alerta.HasKey(a => a.AlertaId);
+        alerta.Property(a => a.AlertaId).HasColumnName("alerta_id");
+        alerta.Property(a => a.CodigoVehiculo).HasColumnName("codigo_vehiculo");
+        alerta.Property(a => a.CodigoConductor).HasColumnName("codigo_conductor");
+        alerta.Property(a => a.CodigoRuta).HasColumnName("codigo_ruta");
+        alerta.Property(a => a.RegistroId).HasColumnName("registro_id");
+        alerta.Property(a => a.TipoMaquinaria).HasColumnName("tipo_maquinaria");
+        alerta.Property(a => a.TipoAlerta).HasColumnName("tipo_alerta");
+        alerta.Property(a => a.PorcentajeDiferencia).HasColumnName("porcentaje_diferencia");
+        alerta.Property(a => a.Estado).HasColumnName("estado");
+        alerta.Property(a => a.Descripcion).HasColumnName("descripcion");
+        alerta.Property(a => a.CreadoEn).HasColumnName("creado_en");
+        alerta.Property(a => a.RevisadoEn).HasColumnName("revisado_en");
+        alerta.Property(a => a.RevisadoPor).HasColumnName("revisado_por");
+    }
+}

--- a/alerts-service/alerts-service/Program.cs
+++ b/alerts-service/alerts-service/Program.cs
@@ -1,0 +1,16 @@
+using AlertsService.Persistence;
+using AlertsService.Services;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddGrpc();
+builder.Services.AddDbContext<AlertsDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+var app = builder.Build();
+
+app.MapGrpcService<AlertsGrpcService>();
+app.MapGet("/", () => "gRPC service for alerts");
+
+app.Run();

--- a/alerts-service/alerts-service/Properties/launchSettings.json
+++ b/alerts-service/alerts-service/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5127"
+    },
+    "https": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:7127;http://localhost:5127"
+    },
+    "Container (Dockerfile)": {
+      "commandName": "Docker",
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}",
+      "environmentVariables": {
+        "ASPNETCORE_HTTPS_PORTS": "8081",
+        "ASPNETCORE_HTTP_PORTS": "8080"
+      },
+      "publishAllPorts": true,
+      "useSSL": true
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json"
+}

--- a/alerts-service/alerts-service/Protos/alerts.proto
+++ b/alerts-service/alerts-service/Protos/alerts.proto
@@ -1,0 +1,71 @@
+syntax = "proto3";
+
+option csharp_namespace = "AlertsService";
+
+package alerts;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+message AlertaDto {
+  int32 alertaId = 1;
+  string codigoVehiculo = 2;
+  string codigoConductor = 3;
+  string codigoRuta = 4;
+  int32 registroId = 5;
+  string tipoMaquinaria = 6;
+  string tipoAlerta = 7;
+  double porcentajeDiferencia = 8;
+  bool estado = 9;
+  string descripcion = 10;
+  google.protobuf.Timestamp creadoEn = 11;
+  google.protobuf.Timestamp revisadoEn = 12;
+  string revisadoPor = 13;
+}
+
+message AlertaCreateRequest {
+  string codigoVehiculo = 1;
+  string codigoConductor = 2;
+  string codigoRuta = 3;
+  int32 registroId = 4;
+  string tipoMaquinaria = 5;
+  string tipoAlerta = 6;
+  double porcentajeDiferencia = 7;
+  bool estado = 8;
+  string descripcion = 9;
+}
+
+message AlertaIdRequest { int32 alertaId = 1; }
+
+message AlertaUpdateRequest {
+  int32 alertaId = 1;
+  optional string codigoVehiculo = 2;
+  optional string codigoConductor = 3;
+  optional string codigoRuta = 4;
+  optional int32 registroId = 5;
+  optional string tipoMaquinaria = 6;
+  optional string tipoAlerta = 7;
+  optional double porcentajeDiferencia = 8;
+  optional bool estado = 9;
+  optional string descripcion = 10;
+  optional google.protobuf.Timestamp revisadoEn = 11;
+  optional string revisadoPor = 12;
+}
+
+message CodigoVehiculoRequest { string codigoVehiculo = 1; }
+message CodigoConductorRequest { string codigoConductor = 1; }
+message CodigoRutaRequest { string codigoRuta = 1; }
+
+message ListaAlertas { repeated AlertaDto alertas = 1; }
+
+service AlertsService {
+  rpc CrearAlerta (AlertaCreateRequest) returns (AlertaDto);
+  rpc ObtenerAlerta (AlertaIdRequest) returns (AlertaDto);
+  rpc ListarAlertas (google.protobuf.Empty) returns (ListaAlertas);
+  rpc EditarAlerta (AlertaUpdateRequest) returns (AlertaDto);
+  rpc EliminarAlerta (AlertaIdRequest) returns (google.protobuf.Empty);
+
+  rpc AlertasPorVehiculo (CodigoVehiculoRequest) returns (ListaAlertas);
+  rpc AlertasPorConductor (CodigoConductorRequest) returns (ListaAlertas);
+  rpc AlertasPorRuta (CodigoRutaRequest) returns (ListaAlertas);
+}

--- a/alerts-service/alerts-service/Services/AlertsGrpcService.cs
+++ b/alerts-service/alerts-service/Services/AlertsGrpcService.cs
@@ -1,0 +1,126 @@
+using AlertsService.Domain.Entities;
+using AlertsService.Persistence;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Microsoft.EntityFrameworkCore;
+
+namespace AlertsService.Services;
+
+public class AlertsGrpcService : AlertsService.AlertsServiceBase
+{
+    private readonly AlertsDbContext _context;
+
+    public AlertsGrpcService(AlertsDbContext context)
+    {
+        _context = context;
+    }
+
+    private static AlertaDto ToDto(AlertaConsumo a) => new()
+    {
+        AlertaId = a.AlertaId,
+        CodigoVehiculo = a.CodigoVehiculo,
+        CodigoConductor = a.CodigoConductor,
+        CodigoRuta = a.CodigoRuta,
+        RegistroId = a.RegistroId,
+        TipoMaquinaria = a.TipoMaquinaria,
+        TipoAlerta = a.TipoAlerta,
+        PorcentajeDiferencia = (double)a.PorcentajeDiferencia,
+        Estado = a.Estado,
+        Descripcion = a.Descripcion ?? string.Empty,
+        CreadoEn = Timestamp.FromDateTime(a.CreadoEn.ToUniversalTime()),
+        RevisadoEn = a.RevisadoEn != null ? Timestamp.FromDateTime(a.RevisadoEn.Value.ToUniversalTime()) : null,
+        RevisadoPor = a.RevisadoPor ?? string.Empty
+    };
+
+    public override async Task<AlertaDto> CrearAlerta(AlertaCreateRequest request, ServerCallContext context)
+    {
+        var entity = new AlertaConsumo
+        {
+            CodigoVehiculo = request.CodigoVehiculo,
+            CodigoConductor = request.CodigoConductor,
+            CodigoRuta = request.CodigoRuta,
+            RegistroId = request.RegistroId,
+            TipoMaquinaria = request.TipoMaquinaria,
+            TipoAlerta = request.TipoAlerta,
+            PorcentajeDiferencia = (decimal)request.PorcentajeDiferencia,
+            Estado = request.Estado,
+            Descripcion = request.Descripcion,
+            CreadoEn = DateTime.UtcNow
+        };
+        _context.AlertasConsumo.Add(entity);
+        await _context.SaveChangesAsync();
+        return ToDto(entity);
+    }
+
+    public override async Task<AlertaDto> ObtenerAlerta(AlertaIdRequest request, ServerCallContext context)
+    {
+        var entity = await _context.AlertasConsumo.FindAsync(request.AlertaId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Alerta no encontrada"));
+        return ToDto(entity);
+    }
+
+    public override async Task<ListaAlertas> ListarAlertas(Empty request, ServerCallContext context)
+    {
+        var list = await _context.AlertasConsumo.ToListAsync();
+        var res = new ListaAlertas();
+        res.Alertas.AddRange(list.Select(ToDto));
+        return res;
+    }
+
+    public override async Task<AlertaDto> EditarAlerta(AlertaUpdateRequest request, ServerCallContext context)
+    {
+        var entity = await _context.AlertasConsumo.FindAsync(request.AlertaId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Alerta no encontrada"));
+
+        if (request.HasCodigoVehiculo) entity.CodigoVehiculo = request.CodigoVehiculo;
+        if (request.HasCodigoConductor) entity.CodigoConductor = request.CodigoConductor;
+        if (request.HasCodigoRuta) entity.CodigoRuta = request.CodigoRuta;
+        if (request.HasRegistroId) entity.RegistroId = request.RegistroId;
+        if (request.HasTipoMaquinaria) entity.TipoMaquinaria = request.TipoMaquinaria;
+        if (request.HasTipoAlerta) entity.TipoAlerta = request.TipoAlerta;
+        if (request.HasPorcentajeDiferencia) entity.PorcentajeDiferencia = (decimal)request.PorcentajeDiferencia;
+        if (request.HasEstado) entity.Estado = request.Estado;
+        if (request.HasDescripcion) entity.Descripcion = request.Descripcion;
+        if (request.RevisadoEn != null) entity.RevisadoEn = request.RevisadoEn.ToDateTime();
+        if (request.HasRevisadoPor) entity.RevisadoPor = request.RevisadoPor;
+
+        await _context.SaveChangesAsync();
+        return ToDto(entity);
+    }
+
+    public override async Task<Empty> EliminarAlerta(AlertaIdRequest request, ServerCallContext context)
+    {
+        var entity = await _context.AlertasConsumo.FindAsync(request.AlertaId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Alerta no encontrada"));
+        _context.AlertasConsumo.Remove(entity);
+        await _context.SaveChangesAsync();
+        return new Empty();
+    }
+
+    public override async Task<ListaAlertas> AlertasPorVehiculo(CodigoVehiculoRequest request, ServerCallContext context)
+    {
+        var list = await _context.AlertasConsumo.Where(a => a.CodigoVehiculo == request.CodigoVehiculo).ToListAsync();
+        var res = new ListaAlertas();
+        res.Alertas.AddRange(list.Select(ToDto));
+        return res;
+    }
+
+    public override async Task<ListaAlertas> AlertasPorConductor(CodigoConductorRequest request, ServerCallContext context)
+    {
+        var list = await _context.AlertasConsumo.Where(a => a.CodigoConductor == request.CodigoConductor).ToListAsync();
+        var res = new ListaAlertas();
+        res.Alertas.AddRange(list.Select(ToDto));
+        return res;
+    }
+
+    public override async Task<ListaAlertas> AlertasPorRuta(CodigoRutaRequest request, ServerCallContext context)
+    {
+        var list = await _context.AlertasConsumo.Where(a => a.CodigoRuta == request.CodigoRuta).ToListAsync();
+        var res = new ListaAlertas();
+        res.Alertas.AddRange(list.Select(ToDto));
+        return res;
+    }
+}

--- a/alerts-service/alerts-service/alerts-service.csproj
+++ b/alerts-service/alerts-service/alerts-service.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos/alerts.proto" GrpcServices="Server" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Grpc.Tools" Version="2.71.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Google.Protobuf" Version="3.30.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+  </ItemGroup>
+
+</Project>

--- a/alerts-service/alerts-service/appsettings.json
+++ b/alerts-service/alerts-service/appsettings.json
@@ -1,0 +1,17 @@
+{
+    "ConnectionStrings": {
+        "DefaultConnection": "Server=localhost;Database=alerts_db;Trusted_Connection=True;TrustServerCertificate=True;"
+    },
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*",
+    "Kestrel": {
+        "EndpointDefaults": {
+            "Protocols": "Http2"
+        }
+    }
+}

--- a/api gateway/Gateway.API/Gateway.API/Controllers/AlertasController.cs
+++ b/api gateway/Gateway.API/Gateway.API/Controllers/AlertasController.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Mvc;
+using Gateway.API.GrpcClients;
+using Gateway.API.Models;
+
+namespace Gateway.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AlertasController : ControllerBase
+{
+    private readonly AlertsGrpcClient _grpcClient;
+
+    public AlertasController(AlertsGrpcClient grpcClient)
+    {
+        _grpcClient = grpcClient;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Get()
+    {
+        var items = await _grpcClient.GetAllAsync();
+        return Ok(items);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetById(int id)
+    {
+        var alerta = await _grpcClient.GetByIdAsync(id);
+        if (alerta == null)
+            return NotFound();
+        return Ok(alerta);
+    }
+
+    [HttpGet("vehiculo/{codigo}")]
+    public async Task<IActionResult> PorVehiculo(string codigo)
+    {
+        var items = await _grpcClient.GetByVehiculoAsync(codigo);
+        return Ok(items);
+    }
+
+    [HttpGet("conductor/{codigo}")]
+    public async Task<IActionResult> PorConductor(string codigo)
+    {
+        var items = await _grpcClient.GetByConductorAsync(codigo);
+        return Ok(items);
+    }
+
+    [HttpGet("ruta/{codigo}")]
+    public async Task<IActionResult> PorRuta(string codigo)
+    {
+        var items = await _grpcClient.GetByRutaAsync(codigo);
+        return Ok(items);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] AlertaCreateRequestModel request)
+    {
+        var created = await _grpcClient.CreateAsync(request);
+        return Ok(created);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(int id, [FromBody] AlertaUpdateRequestModel request)
+    {
+        var updated = await _grpcClient.UpdateAsync(id, request);
+        return Ok(updated);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var ok = await _grpcClient.DeleteAsync(id);
+        if (!ok) return NotFound();
+        return NoContent();
+    }
+}

--- a/api gateway/Gateway.API/Gateway.API/Gateway.API.csproj
+++ b/api gateway/Gateway.API/Gateway.API/Gateway.API.csproj
@@ -23,6 +23,7 @@
                 <Protobuf Include="Protos\driver.proto" GrpcServices="Client" />
                 <Protobuf Include="Protos\fuel.proto" GrpcServices="Client" />
                 <Protobuf Include="Protos\routes.proto" GrpcServices="Client" />
+                <Protobuf Include="Protos\alerts.proto" GrpcServices="Client" />
 
         </ItemGroup>
 

--- a/api gateway/Gateway.API/Gateway.API/GrpcClients/AlertsGrpcClient.cs
+++ b/api gateway/Gateway.API/Gateway.API/GrpcClients/AlertsGrpcClient.cs
@@ -1,0 +1,139 @@
+using Grpc.Net.Client;
+using Gateway.API.Models;
+using Google.Protobuf.WellKnownTypes;
+using AlertsService;
+
+namespace Gateway.API.GrpcClients;
+
+public class AlertsGrpcClient
+{
+    private readonly AlertsService.AlertsServiceClient _client;
+
+    public AlertsGrpcClient(IConfiguration configuration)
+    {
+        var url = configuration["GrpcSettings:AlertsService"];
+        if (string.IsNullOrWhiteSpace(url))
+            throw new InvalidOperationException("No se configuró la URL del microservicio de alertas.");
+
+        var channel = GrpcChannel.ForAddress(url);
+        _client = new AlertsService.AlertsServiceClient(channel);
+    }
+
+    public async Task<IEnumerable<AlertaDto>> GetAllAsync()
+    {
+        var response = await _client.ListarAlertasAsync(new Empty());
+        return response.Alertas.Select(a => new AlertaDto
+        {
+            AlertaId = a.AlertaId,
+            CodigoVehiculo = a.CodigoVehiculo,
+            CodigoConductor = a.CodigoConductor,
+            CodigoRuta = a.CodigoRuta,
+            RegistroId = a.RegistroId,
+            TipoMaquinaria = a.TipoMaquinaria,
+            TipoAlerta = a.TipoAlerta,
+            PorcentajeDiferencia = a.PorcentajeDiferencia,
+            Estado = a.Estado,
+            Descripcion = a.Descripcion,
+            CreadoEn = a.CreadoEn.ToDateTime(),
+            RevisadoEn = a.RevisadoEn.ToDateTime(),
+            RevisadoPor = a.RevisadoPor
+        });
+    }
+
+    public async Task<IEnumerable<AlertaDto>> GetByVehiculoAsync(string codigo)
+    {
+        var response = await _client.AlertasPorVehiculoAsync(new CodigoVehiculoRequest { CodigoVehiculo = codigo });
+        return response.Alertas.Select(MapDto);
+    }
+
+    public async Task<IEnumerable<AlertaDto>> GetByConductorAsync(string codigo)
+    {
+        var response = await _client.AlertasPorConductorAsync(new CodigoConductorRequest { CodigoConductor = codigo });
+        return response.Alertas.Select(MapDto);
+    }
+
+    public async Task<IEnumerable<AlertaDto>> GetByRutaAsync(string codigo)
+    {
+        var response = await _client.AlertasPorRutaAsync(new CodigoRutaRequest { CodigoRuta = codigo });
+        return response.Alertas.Select(MapDto);
+    }
+
+    public async Task<AlertaDto?> GetByIdAsync(int id)
+    {
+        try
+        {
+            var a = await _client.ObtenerAlertaAsync(new AlertaIdRequest { AlertaId = id });
+            return MapDto(a);
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<AlertaDto> CreateAsync(AlertaCreateRequestModel request)
+    {
+        var grpcRequest = new AlertsService.AlertaCreateRequest
+        {
+            CodigoVehiculo = request.CodigoVehiculo,
+            CodigoConductor = request.CodigoConductor,
+            CodigoRuta = request.CodigoRuta,
+            RegistroId = request.RegistroId,
+            TipoMaquinaria = request.TipoMaquinaria,
+            TipoAlerta = request.TipoAlerta,
+            PorcentajeDiferencia = request.PorcentajeDiferencia,
+            Estado = request.Estado,
+            Descripcion = request.Descripcion
+        };
+        var a = await _client.CrearAlertaAsync(grpcRequest);
+        return MapDto(a);
+    }
+
+    public async Task<AlertaDto> UpdateAsync(int id, AlertaUpdateRequestModel request)
+    {
+        var grpcRequest = new AlertsService.AlertaUpdateRequest { AlertaId = id };
+        if (request.CodigoVehiculo != null) grpcRequest.CodigoVehiculo = request.CodigoVehiculo;
+        if (request.CodigoConductor != null) grpcRequest.CodigoConductor = request.CodigoConductor;
+        if (request.CodigoRuta != null) grpcRequest.CodigoRuta = request.CodigoRuta;
+        if (request.RegistroId.HasValue) grpcRequest.RegistroId = request.RegistroId.Value;
+        if (request.TipoMaquinaria != null) grpcRequest.TipoMaquinaria = request.TipoMaquinaria;
+        if (request.TipoAlerta != null) grpcRequest.TipoAlerta = request.TipoAlerta;
+        if (request.PorcentajeDiferencia.HasValue) grpcRequest.PorcentajeDiferencia = request.PorcentajeDiferencia.Value;
+        if (request.Estado.HasValue) grpcRequest.Estado = request.Estado.Value;
+        if (request.Descripcion != null) grpcRequest.Descripcion = request.Descripcion;
+        if (request.RevisadoEn.HasValue) grpcRequest.RevisadoEn = Timestamp.FromDateTime(request.RevisadoEn.Value.ToUniversalTime());
+        if (request.RevisadoPor != null) grpcRequest.RevisadoPor = request.RevisadoPor;
+        var a = await _client.EditarAlertaAsync(grpcRequest);
+        return MapDto(a);
+    }
+
+    public async Task<bool> DeleteAsync(int id)
+    {
+        try
+        {
+            await _client.EliminarAlertaAsync(new AlertaIdRequest { AlertaId = id });
+            return true;
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return false;
+        }
+    }
+
+    private static AlertaDto MapDto(AlertsService.AlertaDto a) => new AlertaDto
+    {
+        AlertaId = a.AlertaId,
+        CodigoVehiculo = a.CodigoVehiculo,
+        CodigoConductor = a.CodigoConductor,
+        CodigoRuta = a.CodigoRuta,
+        RegistroId = a.RegistroId,
+        TipoMaquinaria = a.TipoMaquinaria,
+        TipoAlerta = a.TipoAlerta,
+        PorcentajeDiferencia = a.PorcentajeDiferencia,
+        Estado = a.Estado,
+        Descripcion = a.Descripcion,
+        CreadoEn = a.CreadoEn.ToDateTime(),
+        RevisadoEn = a.RevisadoEn.ToDateTime(),
+        RevisadoPor = a.RevisadoPor
+    };
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/AlertaCreateRequestModel.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/AlertaCreateRequestModel.cs
@@ -1,0 +1,14 @@
+namespace Gateway.API.Models;
+
+public class AlertaCreateRequestModel
+{
+    public string CodigoVehiculo { get; set; } = string.Empty;
+    public string CodigoConductor { get; set; } = string.Empty;
+    public string CodigoRuta { get; set; } = string.Empty;
+    public int RegistroId { get; set; }
+    public string TipoMaquinaria { get; set; } = string.Empty;
+    public string TipoAlerta { get; set; } = string.Empty;
+    public double PorcentajeDiferencia { get; set; }
+    public bool Estado { get; set; }
+    public string? Descripcion { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/AlertaDto.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/AlertaDto.cs
@@ -1,0 +1,18 @@
+namespace Gateway.API.Models;
+
+public class AlertaDto
+{
+    public int AlertaId { get; set; }
+    public string CodigoVehiculo { get; set; } = string.Empty;
+    public string CodigoConductor { get; set; } = string.Empty;
+    public string CodigoRuta { get; set; } = string.Empty;
+    public int RegistroId { get; set; }
+    public string TipoMaquinaria { get; set; } = string.Empty;
+    public string TipoAlerta { get; set; } = string.Empty;
+    public double PorcentajeDiferencia { get; set; }
+    public bool Estado { get; set; }
+    public string? Descripcion { get; set; }
+    public DateTime CreadoEn { get; set; }
+    public DateTime? RevisadoEn { get; set; }
+    public string? RevisadoPor { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/AlertaUpdateRequestModel.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/AlertaUpdateRequestModel.cs
@@ -1,0 +1,16 @@
+namespace Gateway.API.Models;
+
+public class AlertaUpdateRequestModel
+{
+    public string? CodigoVehiculo { get; set; }
+    public string? CodigoConductor { get; set; }
+    public string? CodigoRuta { get; set; }
+    public int? RegistroId { get; set; }
+    public string? TipoMaquinaria { get; set; }
+    public string? TipoAlerta { get; set; }
+    public double? PorcentajeDiferencia { get; set; }
+    public bool? Estado { get; set; }
+    public string? Descripcion { get; set; }
+    public DateTime? RevisadoEn { get; set; }
+    public string? RevisadoPor { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Program.cs
+++ b/api gateway/Gateway.API/Gateway.API/Program.cs
@@ -14,6 +14,7 @@ builder.Services.AddSingleton<DriverGrpcClient>();
 
 builder.Services.AddSingleton<FuelGrpcClient>();
 builder.Services.AddSingleton<RouteGrpcClient>();
+builder.Services.AddSingleton<AlertsGrpcClient>();
 
 
 

--- a/api gateway/Gateway.API/Gateway.API/Protos/alerts.proto
+++ b/api gateway/Gateway.API/Gateway.API/Protos/alerts.proto
@@ -1,0 +1,71 @@
+syntax = "proto3";
+
+option csharp_namespace = "AlertsService";
+
+package alerts;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+message AlertaDto {
+  int32 alertaId = 1;
+  string codigoVehiculo = 2;
+  string codigoConductor = 3;
+  string codigoRuta = 4;
+  int32 registroId = 5;
+  string tipoMaquinaria = 6;
+  string tipoAlerta = 7;
+  double porcentajeDiferencia = 8;
+  bool estado = 9;
+  string descripcion = 10;
+  google.protobuf.Timestamp creadoEn = 11;
+  google.protobuf.Timestamp revisadoEn = 12;
+  string revisadoPor = 13;
+}
+
+message AlertaCreateRequest {
+  string codigoVehiculo = 1;
+  string codigoConductor = 2;
+  string codigoRuta = 3;
+  int32 registroId = 4;
+  string tipoMaquinaria = 5;
+  string tipoAlerta = 6;
+  double porcentajeDiferencia = 7;
+  bool estado = 8;
+  string descripcion = 9;
+}
+
+message AlertaIdRequest { int32 alertaId = 1; }
+
+message AlertaUpdateRequest {
+  int32 alertaId = 1;
+  optional string codigoVehiculo = 2;
+  optional string codigoConductor = 3;
+  optional string codigoRuta = 4;
+  optional int32 registroId = 5;
+  optional string tipoMaquinaria = 6;
+  optional string tipoAlerta = 7;
+  optional double porcentajeDiferencia = 8;
+  optional bool estado = 9;
+  optional string descripcion = 10;
+  optional google.protobuf.Timestamp revisadoEn = 11;
+  optional string revisadoPor = 12;
+}
+
+message CodigoVehiculoRequest { string codigoVehiculo = 1; }
+message CodigoConductorRequest { string codigoConductor = 1; }
+message CodigoRutaRequest { string codigoRuta = 1; }
+
+message ListaAlertas { repeated AlertaDto alertas = 1; }
+
+service AlertsService {
+  rpc CrearAlerta (AlertaCreateRequest) returns (AlertaDto);
+  rpc ObtenerAlerta (AlertaIdRequest) returns (AlertaDto);
+  rpc ListarAlertas (google.protobuf.Empty) returns (ListaAlertas);
+  rpc EditarAlerta (AlertaUpdateRequest) returns (AlertaDto);
+  rpc EliminarAlerta (AlertaIdRequest) returns (google.protobuf.Empty);
+
+  rpc AlertasPorVehiculo (CodigoVehiculoRequest) returns (ListaAlertas);
+  rpc AlertasPorConductor (CodigoConductorRequest) returns (ListaAlertas);
+  rpc AlertasPorRuta (CodigoRutaRequest) returns (ListaAlertas);
+}

--- a/api gateway/Gateway.API/Gateway.API/appsettings.json
+++ b/api gateway/Gateway.API/Gateway.API/appsettings.json
@@ -2,8 +2,9 @@
     "GrpcSettings": {
         "VehiclesService": "http://localhost:5117",
         "DriversService": "http://localhost:5120",
-        "FuelService": "http://localhost:5125"
-        "RoutesService": "http://localhost:5123"
+        "FuelService": "http://localhost:5125",
+        "RoutesService": "http://localhost:5123",
+        "AlertsService": "http://localhost:5127"
 
     },
     "Logging": {


### PR DESCRIPTION
## Summary
- create **alerts-service** with CRUD gRPC API
- integrate alerts gRPC proto and client into API Gateway
- expose alerts endpoints in API Gateway
- add Dockerfile and configuration for new service

## Testing
- `dotnet build alerts-service/alerts-service/alerts-service.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686311b1004483338233a22c573f6752