### PR TITLE
Add compose and db init

### DIFF
--- a/alerts-service/alerts-service/Program.cs
+++ b/alerts-service/alerts-service/Program.cs
@@ -10,6 +10,13 @@ builder.Services.AddDbContext<AlertsDbContext>(options =>
 
 var app = builder.Build();
 
+// Ensure database is created on startup
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AlertsDbContext>();
+    db.Database.EnsureCreated();
+}
+
 app.MapGrpcService<AlertsGrpcService>();
 app.MapGet("/", () => "gRPC service for alerts");
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,73 @@
+version: '3.9'
+services:
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: sqlserver
+    environment:
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: "Your_password123"
+    ports:
+      - "1433:1433"
+
+  vehicles-service:
+    build: ./vehicles-service/vehicle-service/vehicle-service
+    environment:
+      ConnectionStrings__DefaultConnection: "Server=sqlserver;Database=vehicle_db;User Id=sa;Password=Your_password123;TrustServerCertificate=True;"
+    depends_on:
+      - sqlserver
+    ports:
+      - "5117:8080"
+
+  drivers-service:
+    build: ./drivers-service/drivers-service
+    environment:
+      ConnectionStrings__DefaultConnection: "Server=sqlserver;Database=drivers_db;User Id=sa;Password=Your_password123;TrustServerCertificate=True;"
+    depends_on:
+      - sqlserver
+    ports:
+      - "5120:8080"
+
+  fuel-service:
+    build: ./fuel-service/fuel-service
+    environment:
+      ConnectionStrings__DefaultConnection: "Server=sqlserver;Database=fuel_db;User Id=sa;Password=Your_password123;TrustServerCertificate=True;"
+    depends_on:
+      - sqlserver
+    ports:
+      - "5125:8080"
+
+  routes-service:
+    build: ./routes-service/routes-service
+    environment:
+      ConnectionStrings__DefaultConnection: "Server=sqlserver;Database=routes_db;User Id=sa;Password=Your_password123;TrustServerCertificate=True;"
+    depends_on:
+      - sqlserver
+    ports:
+      - "5123:8080"
+
+  alerts-service:
+    build: ./alerts-service/alerts-service
+    environment:
+      ConnectionStrings__DefaultConnection: "Server=sqlserver;Database=alerts_db;User Id=sa;Password=Your_password123;TrustServerCertificate=True;"
+    depends_on:
+      - sqlserver
+    ports:
+      - "5127:8080"
+
+  gateway:
+    build:
+      context: "./api gateway/Gateway.API/Gateway.API"
+    environment:
+      GrpcSettings__VehiclesService: "http://vehicles-service:8080"
+      GrpcSettings__DriversService: "http://drivers-service:8080"
+      GrpcSettings__FuelService: "http://fuel-service:8080"
+      GrpcSettings__RoutesService: "http://routes-service:8080"
+      GrpcSettings__AlertsService: "http://alerts-service:8080"
+    depends_on:
+      - vehicles-service
+      - drivers-service
+      - fuel-service
+      - routes-service
+      - alerts-service
+    ports:
+      - "8080:8080"

--- a/drivers-service/drivers-service/Program.cs
+++ b/drivers-service/drivers-service/Program.cs
@@ -10,6 +10,13 @@ builder.Services.AddDbContext<DriversDbContext>(options =>
 
 var app = builder.Build();
 
+// Ensure database is created on startup
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<DriversDbContext>();
+    db.Database.EnsureCreated();
+}
+
 app.MapGrpcService<DriverGrpcService>();
 app.MapGet("/", () => "gRPC service for drivers");
 

--- a/fuel-service/fuel-service/Program.cs
+++ b/fuel-service/fuel-service/Program.cs
@@ -10,6 +10,13 @@ builder.Services.AddDbContext<FuelDbContext>(options =>
 
 var app = builder.Build();
 
+// Ensure database is created on startup
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<FuelDbContext>();
+    db.Database.EnsureCreated();
+}
+
 app.MapGrpcService<FuelGrpcService>();
 app.MapGet("/", () => "gRPC service for fuel management");
 

--- a/routes-service/routes-service/Program.cs
+++ b/routes-service/routes-service/Program.cs
@@ -10,6 +10,13 @@ builder.Services.AddDbContext<RoutesDbContext>(options =>
 
 var app = builder.Build();
 
+// Ensure database is created on startup
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<RoutesDbContext>();
+    db.Database.EnsureCreated();
+}
+
 app.MapGrpcService<RouteGrpcService>();
 app.MapGet("/", () => "gRPC service for routes");
 

--- a/vehicles-service/vehicle-service/vehicle-service/Program.cs
+++ b/vehicles-service/vehicle-service/vehicle-service/Program.cs
@@ -13,6 +13,13 @@ builder.Services.AddDbContext<VehicleDbContext>(options =>
 
 var app = builder.Build();
 
+// Ensure database is created on startup
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<VehicleDbContext>();
+    db.Database.EnsureCreated();
+}
+
 // Configure the HTTP request pipeline.
 app.MapGrpcService<VehiculoGrpcService>();
 app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");


### PR DESCRIPTION
## Summary
- ensure each microservice creates its database on startup
- provide docker-compose environment for sql server and all services

## Testing
- `dotnet build fuel-service/fuel-service/fuel-service.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869e88fe65c8333b59e012e4fec99b6