### PR TITLE
Enable swagger in API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # Gestion_Combustibles
 
 #Prueba
+
+## Swagger de API Gateway
+
+Al iniciar el proyecto con `docker compose up --build`, el API Gateway se 
+expone en el puerto `8080`. Puede acceder a la documentación Swagger en:
+
+```
+http://localhost:8080/swagger
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,8 @@ services:
       GrpcSettings__FuelService: "http://fuel-service:8080"
       GrpcSettings__RoutesService: "http://routes-service:8080"
       GrpcSettings__AlertsService: "http://alerts-service:8080"
+      # Enable Swagger in the gateway by running in Development mode
+      ASPNETCORE_ENVIRONMENT: Development
     depends_on:
       - vehicles-service
       - drivers-service


### PR DESCRIPTION
## Summary
- enable Swagger UI by setting `ASPNETCORE_ENVIRONMENT` for the API gateway
- document Swagger endpoint in README

## Testing
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b27c185ac8333b5053cb3ce75afd6