### PR TITLE
Implement CRUD for routes and add machinery endpoint

### DIFF
--- a/api gateway/Gateway.API/Gateway.API/Controllers/ConsumoMaquinariaController.cs
+++ b/api gateway/Gateway.API/Gateway.API/Controllers/ConsumoMaquinariaController.cs
@@ -1,0 +1,23 @@
+using Gateway.API.GrpcClients;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Gateway.API.Controllers;
+
+[ApiController]
+[Route("api/consumo-maquinaria")]
+public class ConsumoMaquinariaController : ControllerBase
+{
+    private readonly FuelGrpcClient _grpcClient;
+
+    public ConsumoMaquinariaController(FuelGrpcClient grpcClient)
+    {
+        _grpcClient = grpcClient;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Get()
+    {
+        var items = await _grpcClient.GetConsumoTipoMaquinariaAsync();
+        return Ok(items);
+    }
+}

--- a/api gateway/Gateway.API/Gateway.API/Controllers/RutasController.cs
+++ b/api gateway/Gateway.API/Gateway.API/Controllers/RutasController.cs
@@ -21,6 +21,37 @@ public class RutasController : ControllerBase
         return Ok(rutas);
     }
 
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetById(int id)
+    {
+        var ruta = await _grpcClient.ObtenerRutaAsync(id);
+        if (ruta == null) return NotFound();
+        return Ok(ruta);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] Gateway.API.Models.RutaCreateRequest request)
+    {
+        var created = await _grpcClient.CrearRutaAsync(request);
+        return Ok(created);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(int id, [FromBody] Gateway.API.Models.RutaUpdateRequest request)
+    {
+        var updated = await _grpcClient.EditarRutaAsync(id, request);
+        if (updated == null) return NotFound();
+        return Ok(updated);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var ok = await _grpcClient.EliminarRutaAsync(id);
+        if (!ok) return NotFound();
+        return NoContent();
+    }
+
     [HttpGet("ubicaciones")]
     public async Task<IActionResult> GetUbicaciones()
     {
@@ -28,10 +59,72 @@ public class RutasController : ControllerBase
         return Ok(ubicaciones);
     }
 
+    [HttpGet("ubicaciones/{id}")]
+    public async Task<IActionResult> GetUbicacionById(int id)
+    {
+        var ubicacion = await _grpcClient.ObtenerUbicacionAsync(id);
+        if (ubicacion == null) return NotFound();
+        return Ok(ubicacion);
+    }
+
+    [HttpPost("ubicaciones")]
+    public async Task<IActionResult> CreateUbicacion([FromBody] Gateway.API.Models.UbicacionCreateRequest request)
+    {
+        var created = await _grpcClient.CrearUbicacionAsync(request);
+        return Ok(created);
+    }
+
+    [HttpPut("ubicaciones/{id}")]
+    public async Task<IActionResult> UpdateUbicacion(int id, [FromBody] Gateway.API.Models.UbicacionUpdateRequest request)
+    {
+        var updated = await _grpcClient.EditarUbicacionAsync(id, request);
+        if (updated == null) return NotFound();
+        return Ok(updated);
+    }
+
+    [HttpDelete("ubicaciones/{id}")]
+    public async Task<IActionResult> DeleteUbicacion(int id)
+    {
+        var ok = await _grpcClient.EliminarUbicacionAsync(id);
+        if (!ok) return NotFound();
+        return NoContent();
+    }
+
     [HttpGet("segmentos")]
     public async Task<IActionResult> GetSegmentos()
     {
         var segmentos = await _grpcClient.ListarSegmentosAsync();
         return Ok(segmentos);
+    }
+
+    [HttpGet("segmentos/{id}")]
+    public async Task<IActionResult> GetSegmentoById(int id)
+    {
+        var segmento = await _grpcClient.ObtenerSegmentoAsync(id);
+        if (segmento == null) return NotFound();
+        return Ok(segmento);
+    }
+
+    [HttpPost("segmentos")]
+    public async Task<IActionResult> CreateSegmento([FromBody] Gateway.API.Models.SegmentoCreateRequest request)
+    {
+        var created = await _grpcClient.CrearSegmentoAsync(request);
+        return Ok(created);
+    }
+
+    [HttpPut("segmentos/{id}")]
+    public async Task<IActionResult> UpdateSegmento(int id, [FromBody] Gateway.API.Models.SegmentoUpdateRequest request)
+    {
+        var updated = await _grpcClient.EditarSegmentoAsync(id, request);
+        if (updated == null) return NotFound();
+        return Ok(updated);
+    }
+
+    [HttpDelete("segmentos/{id}")]
+    public async Task<IActionResult> DeleteSegmento(int id)
+    {
+        var ok = await _grpcClient.EliminarSegmentoAsync(id);
+        if (!ok) return NotFound();
+        return NoContent();
     }
 }

--- a/api gateway/Gateway.API/Gateway.API/GrpcClients/FuelGrpcClient.cs
+++ b/api gateway/Gateway.API/Gateway.API/GrpcClients/FuelGrpcClient.cs
@@ -36,4 +36,24 @@ public class FuelGrpcClient
             CostoTotal = r.CostoTotal
         });
     }
+
+    public async Task<IEnumerable<Models.ConsumoTipoMaquinariaDto>> GetConsumoTipoMaquinariaAsync()
+    {
+        var response = await _client.ListarConsumoTipoMaquinariaAsync(new Empty());
+        return response.Consumos.Select(c => new Models.ConsumoTipoMaquinariaDto
+        {
+            ConsumoMaquinariaId = c.ConsumoMaquinariaId,
+            TipoMaquinaria = c.TipoMaquinaria,
+            Periodo = c.Periodo,
+            TotalVehiculos = c.TotalVehiculos,
+            DistanciaTotal = c.DistanciaTotal,
+            CombustibleTotal = c.CombustibleTotal,
+            CostoTotal = c.CostoTotal,
+            ConsumoPromedio = c.ConsumoPromedio,
+            ConsumoEstimado = c.ConsumoEstimado,
+            PorcentajeDiferencia = c.PorcentajeDiferencia,
+            CreadoEn = c.CreadoEn.ToDateTime(),
+            ActualizadoEn = c.ActualizadoEn.ToDateTime()
+        });
+    }
 }

--- a/api gateway/Gateway.API/Gateway.API/GrpcClients/RouteGrpcClient.cs
+++ b/api gateway/Gateway.API/Gateway.API/GrpcClients/RouteGrpcClient.cs
@@ -39,6 +39,112 @@ public class RouteGrpcClient
         });
     }
 
+    public async Task<Gateway.API.Models.RutaDto?> ObtenerRutaAsync(int id)
+    {
+        try
+        {
+            var r = await _client.ObtenerRutaPorIdAsync(new RutaIdRequest { RutaId = id });
+            return new Gateway.API.Models.RutaDto
+            {
+                RutaId = r.RutaId,
+                Codigo = r.Codigo,
+                Nombre = r.Nombre,
+                OrigenId = r.OrigenId,
+                DestinoId = r.DestinoId,
+                Distancia = r.Distancia,
+                TiempoEstimado = r.TiempoEstimado,
+                TipoTerreno = r.TipoTerreno,
+                Descripcion = r.Descripcion,
+                EstaActiva = r.EstaActiva
+            };
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<Gateway.API.Models.RutaDto> CrearRutaAsync(Gateway.API.Models.RutaCreateRequest request)
+    {
+        var grpc = new RutaCreateRequest
+        {
+            Codigo = request.Codigo,
+            Nombre = request.Nombre,
+            OrigenId = request.OrigenId,
+            DestinoId = request.DestinoId,
+            Distancia = request.Distancia,
+            TiempoEstimado = request.TiempoEstimado,
+            TipoTerreno = request.TipoTerreno ?? string.Empty,
+            Descripcion = request.Descripcion ?? string.Empty,
+            EstaActiva = request.EstaActiva
+        };
+
+        var r = await _client.CrearRutaAsync(grpc);
+        return new Gateway.API.Models.RutaDto
+        {
+            RutaId = r.RutaId,
+            Codigo = r.Codigo,
+            Nombre = r.Nombre,
+            OrigenId = r.OrigenId,
+            DestinoId = r.DestinoId,
+            Distancia = r.Distancia,
+            TiempoEstimado = r.TiempoEstimado,
+            TipoTerreno = r.TipoTerreno,
+            Descripcion = r.Descripcion,
+            EstaActiva = r.EstaActiva
+        };
+    }
+
+    public async Task<Gateway.API.Models.RutaDto?> EditarRutaAsync(int id, Gateway.API.Models.RutaUpdateRequest request)
+    {
+        var grpc = new RutaUpdateRequest { RutaId = id };
+
+        if (request.Codigo != null) grpc.Codigo = request.Codigo;
+        if (request.Nombre != null) grpc.Nombre = request.Nombre;
+        if (request.OrigenId.HasValue) grpc.OrigenId = request.OrigenId.Value;
+        if (request.DestinoId.HasValue) grpc.DestinoId = request.DestinoId.Value;
+        if (request.Distancia.HasValue) grpc.Distancia = request.Distancia.Value;
+        if (request.TiempoEstimado.HasValue) grpc.TiempoEstimado = request.TiempoEstimado.Value;
+        if (request.TipoTerreno != null) grpc.TipoTerreno = request.TipoTerreno;
+        if (request.Descripcion != null) grpc.Descripcion = request.Descripcion;
+        if (request.EstaActiva.HasValue) grpc.EstaActiva = request.EstaActiva.Value;
+
+        try
+        {
+            var r = await _client.EditarRutaAsync(grpc);
+            return new Gateway.API.Models.RutaDto
+            {
+                RutaId = r.RutaId,
+                Codigo = r.Codigo,
+                Nombre = r.Nombre,
+                OrigenId = r.OrigenId,
+                DestinoId = r.DestinoId,
+                Distancia = r.Distancia,
+                TiempoEstimado = r.TiempoEstimado,
+                TipoTerreno = r.TipoTerreno,
+                Descripcion = r.Descripcion,
+                EstaActiva = r.EstaActiva
+            };
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<bool> EliminarRutaAsync(int id)
+    {
+        try
+        {
+            await _client.EliminarRutaAsync(new RutaIdRequest { RutaId = id });
+            return true;
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return false;
+        }
+    }
+
     public async Task<IEnumerable<Gateway.API.Models.UbicacionDto>> ListarUbicacionesAsync()
     {
         var response = await _client.ListarUbicacionesAsync(new Empty());
@@ -56,6 +162,107 @@ public class RouteGrpcClient
         });
     }
 
+    public async Task<Gateway.API.Models.UbicacionDto?> ObtenerUbicacionAsync(int id)
+    {
+        try
+        {
+            var u = await _client.ObtenerUbicacionPorIdAsync(new UbicacionIdRequest { UbicacionId = id });
+            return new Gateway.API.Models.UbicacionDto
+            {
+                UbicacionId = u.UbicacionId,
+                Nombre = u.Nombre,
+                Direccion = u.Direccion,
+                Ciudad = u.Ciudad,
+                Estado = u.Estado,
+                Pais = u.Pais,
+                Latitud = u.Latitud,
+                Longitud = u.Longitud,
+                Tipo = u.Tipo
+            };
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<Gateway.API.Models.UbicacionDto> CrearUbicacionAsync(Gateway.API.Models.UbicacionCreateRequest request)
+    {
+        var grpc = new UbicacionCreateRequest
+        {
+            Nombre = request.Nombre,
+            Direccion = request.Direccion ?? string.Empty,
+            Ciudad = request.Ciudad ?? string.Empty,
+            Estado = request.Estado ?? string.Empty,
+            Pais = request.Pais ?? string.Empty,
+            Latitud = request.Latitud,
+            Longitud = request.Longitud,
+            Tipo = request.Tipo ?? string.Empty
+        };
+
+        var u = await _client.CrearUbicacionAsync(grpc);
+        return new Gateway.API.Models.UbicacionDto
+        {
+            UbicacionId = u.UbicacionId,
+            Nombre = u.Nombre,
+            Direccion = u.Direccion,
+            Ciudad = u.Ciudad,
+            Estado = u.Estado,
+            Pais = u.Pais,
+            Latitud = u.Latitud,
+            Longitud = u.Longitud,
+            Tipo = u.Tipo
+        };
+    }
+
+    public async Task<Gateway.API.Models.UbicacionDto?> EditarUbicacionAsync(int id, Gateway.API.Models.UbicacionUpdateRequest request)
+    {
+        var grpc = new UbicacionUpdateRequest { UbicacionId = id };
+
+        if (request.Nombre != null) grpc.Nombre = request.Nombre;
+        if (request.Direccion != null) grpc.Direccion = request.Direccion;
+        if (request.Ciudad != null) grpc.Ciudad = request.Ciudad;
+        if (request.Estado != null) grpc.Estado = request.Estado;
+        if (request.Pais != null) grpc.Pais = request.Pais;
+        if (request.Latitud.HasValue) grpc.Latitud = request.Latitud.Value;
+        if (request.Longitud.HasValue) grpc.Longitud = request.Longitud.Value;
+        if (request.Tipo != null) grpc.Tipo = request.Tipo;
+
+        try
+        {
+            var u = await _client.EditarUbicacionAsync(grpc);
+            return new Gateway.API.Models.UbicacionDto
+            {
+                UbicacionId = u.UbicacionId,
+                Nombre = u.Nombre,
+                Direccion = u.Direccion,
+                Ciudad = u.Ciudad,
+                Estado = u.Estado,
+                Pais = u.Pais,
+                Latitud = u.Latitud,
+                Longitud = u.Longitud,
+                Tipo = u.Tipo
+            };
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<bool> EliminarUbicacionAsync(int id)
+    {
+        try
+        {
+            await _client.EliminarUbicacionAsync(new UbicacionIdRequest { UbicacionId = id });
+            return true;
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return false;
+        }
+    }
+
     public async Task<IEnumerable<Gateway.API.Models.SegmentoDto>> ListarSegmentosAsync()
     {
         var response = await _client.ListarSegmentosAsync(new Empty());
@@ -71,5 +278,106 @@ public class RouteGrpcClient
             TipoTerreno = s.TipoTerreno,
             Descripcion = s.Descripcion
         });
+    }
+
+    public async Task<Gateway.API.Models.SegmentoDto?> ObtenerSegmentoAsync(int id)
+    {
+        try
+        {
+            var s = await _client.ObtenerSegmentoPorIdAsync(new SegmentoIdRequest { SegmentoId = id });
+            return new Gateway.API.Models.SegmentoDto
+            {
+                SegmentoId = s.SegmentoId,
+                RutaId = s.RutaId,
+                NumeroSecuencia = s.NumeroSecuencia,
+                UbicacionInicioId = s.UbicacionInicioId,
+                UbicacionFinId = s.UbicacionFinId,
+                DistanciaSegmento = s.DistanciaSegmento,
+                TiempoSegmento = s.TiempoSegmento,
+                TipoTerreno = s.TipoTerreno,
+                Descripcion = s.Descripcion
+            };
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<Gateway.API.Models.SegmentoDto> CrearSegmentoAsync(Gateway.API.Models.SegmentoCreateRequest request)
+    {
+        var grpc = new SegmentoCreateRequest
+        {
+            RutaId = request.RutaId,
+            NumeroSecuencia = request.NumeroSecuencia,
+            UbicacionInicioId = request.UbicacionInicioId,
+            UbicacionFinId = request.UbicacionFinId,
+            DistanciaSegmento = request.DistanciaSegmento,
+            TiempoSegmento = request.TiempoSegmento,
+            TipoTerreno = request.TipoTerreno ?? string.Empty,
+            Descripcion = request.Descripcion ?? string.Empty
+        };
+
+        var s = await _client.CrearSegmentoAsync(grpc);
+        return new Gateway.API.Models.SegmentoDto
+        {
+            SegmentoId = s.SegmentoId,
+            RutaId = s.RutaId,
+            NumeroSecuencia = s.NumeroSecuencia,
+            UbicacionInicioId = s.UbicacionInicioId,
+            UbicacionFinId = s.UbicacionFinId,
+            DistanciaSegmento = s.DistanciaSegmento,
+            TiempoSegmento = s.TiempoSegmento,
+            TipoTerreno = s.TipoTerreno,
+            Descripcion = s.Descripcion
+        };
+    }
+
+    public async Task<Gateway.API.Models.SegmentoDto?> EditarSegmentoAsync(int id, Gateway.API.Models.SegmentoUpdateRequest request)
+    {
+        var grpc = new SegmentoUpdateRequest { SegmentoId = id };
+
+        if (request.RutaId.HasValue) grpc.RutaId = request.RutaId.Value;
+        if (request.NumeroSecuencia.HasValue) grpc.NumeroSecuencia = request.NumeroSecuencia.Value;
+        if (request.UbicacionInicioId.HasValue) grpc.UbicacionInicioId = request.UbicacionInicioId.Value;
+        if (request.UbicacionFinId.HasValue) grpc.UbicacionFinId = request.UbicacionFinId.Value;
+        if (request.DistanciaSegmento.HasValue) grpc.DistanciaSegmento = request.DistanciaSegmento.Value;
+        if (request.TiempoSegmento.HasValue) grpc.TiempoSegmento = request.TiempoSegmento.Value;
+        if (request.TipoTerreno != null) grpc.TipoTerreno = request.TipoTerreno;
+        if (request.Descripcion != null) grpc.Descripcion = request.Descripcion;
+
+        try
+        {
+            var s = await _client.EditarSegmentoAsync(grpc);
+            return new Gateway.API.Models.SegmentoDto
+            {
+                SegmentoId = s.SegmentoId,
+                RutaId = s.RutaId,
+                NumeroSecuencia = s.NumeroSecuencia,
+                UbicacionInicioId = s.UbicacionInicioId,
+                UbicacionFinId = s.UbicacionFinId,
+                DistanciaSegmento = s.DistanciaSegmento,
+                TiempoSegmento = s.TiempoSegmento,
+                TipoTerreno = s.TipoTerreno,
+                Descripcion = s.Descripcion
+            };
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<bool> EliminarSegmentoAsync(int id)
+    {
+        try
+        {
+            await _client.EliminarSegmentoAsync(new SegmentoIdRequest { SegmentoId = id });
+            return true;
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return false;
+        }
     }
 }

--- a/api gateway/Gateway.API/Gateway.API/Models/ConsumoTipoMaquinariaDto.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/ConsumoTipoMaquinariaDto.cs
@@ -1,0 +1,17 @@
+namespace Gateway.API.Models;
+
+public class ConsumoTipoMaquinariaDto
+{
+    public int ConsumoMaquinariaId { get; set; }
+    public string TipoMaquinaria { get; set; } = string.Empty;
+    public string Periodo { get; set; } = string.Empty;
+    public int TotalVehiculos { get; set; }
+    public double DistanciaTotal { get; set; }
+    public double CombustibleTotal { get; set; }
+    public double CostoTotal { get; set; }
+    public double ConsumoPromedio { get; set; }
+    public double ConsumoEstimado { get; set; }
+    public double PorcentajeDiferencia { get; set; }
+    public DateTime CreadoEn { get; set; }
+    public DateTime ActualizadoEn { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/RutaCreateRequest.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/RutaCreateRequest.cs
@@ -1,0 +1,14 @@
+namespace Gateway.API.Models;
+
+public class RutaCreateRequest
+{
+    public string Codigo { get; set; } = string.Empty;
+    public string Nombre { get; set; } = string.Empty;
+    public int OrigenId { get; set; }
+    public int DestinoId { get; set; }
+    public double Distancia { get; set; }
+    public double TiempoEstimado { get; set; }
+    public string? TipoTerreno { get; set; }
+    public string? Descripcion { get; set; }
+    public bool EstaActiva { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/RutaUpdateRequest.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/RutaUpdateRequest.cs
@@ -1,0 +1,14 @@
+namespace Gateway.API.Models;
+
+public class RutaUpdateRequest
+{
+    public string? Codigo { get; set; }
+    public string? Nombre { get; set; }
+    public int? OrigenId { get; set; }
+    public int? DestinoId { get; set; }
+    public double? Distancia { get; set; }
+    public double? TiempoEstimado { get; set; }
+    public string? TipoTerreno { get; set; }
+    public string? Descripcion { get; set; }
+    public bool? EstaActiva { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/SegmentoCreateRequest.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/SegmentoCreateRequest.cs
@@ -1,0 +1,13 @@
+namespace Gateway.API.Models;
+
+public class SegmentoCreateRequest
+{
+    public int RutaId { get; set; }
+    public int NumeroSecuencia { get; set; }
+    public int UbicacionInicioId { get; set; }
+    public int UbicacionFinId { get; set; }
+    public double DistanciaSegmento { get; set; }
+    public double TiempoSegmento { get; set; }
+    public string? TipoTerreno { get; set; }
+    public string? Descripcion { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/SegmentoUpdateRequest.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/SegmentoUpdateRequest.cs
@@ -1,0 +1,13 @@
+namespace Gateway.API.Models;
+
+public class SegmentoUpdateRequest
+{
+    public int? RutaId { get; set; }
+    public int? NumeroSecuencia { get; set; }
+    public int? UbicacionInicioId { get; set; }
+    public int? UbicacionFinId { get; set; }
+    public double? DistanciaSegmento { get; set; }
+    public double? TiempoSegmento { get; set; }
+    public string? TipoTerreno { get; set; }
+    public string? Descripcion { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/UbicacionCreateRequest.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/UbicacionCreateRequest.cs
@@ -1,0 +1,13 @@
+namespace Gateway.API.Models;
+
+public class UbicacionCreateRequest
+{
+    public string Nombre { get; set; } = string.Empty;
+    public string? Direccion { get; set; }
+    public string? Ciudad { get; set; }
+    public string? Estado { get; set; }
+    public string? Pais { get; set; }
+    public double Latitud { get; set; }
+    public double Longitud { get; set; }
+    public string? Tipo { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/UbicacionUpdateRequest.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/UbicacionUpdateRequest.cs
@@ -1,0 +1,13 @@
+namespace Gateway.API.Models;
+
+public class UbicacionUpdateRequest
+{
+    public string? Nombre { get; set; }
+    public string? Direccion { get; set; }
+    public string? Ciudad { get; set; }
+    public string? Estado { get; set; }
+    public string? Pais { get; set; }
+    public double? Latitud { get; set; }
+    public double? Longitud { get; set; }
+    public string? Tipo { get; set; }
+}


### PR DESCRIPTION
## Summary
- implement full CRUD operations for Rutas, Ubicaciones and Segmentos in the API Gateway
- expose new API controller to query consumo por tipo de maquinaria
- extend gRPC clients to support new operations
- add request/response models for routes service

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b3536674c8333ae2ded7d90099c03