### PR TITLE
Add CRUD for machinery types

### DIFF
--- a/api gateway/Gateway.API/Gateway.API/Controllers/TiposMaquinariaController.cs
+++ b/api gateway/Gateway.API/Gateway.API/Controllers/TiposMaquinariaController.cs
@@ -1,0 +1,55 @@
+using Gateway.API.GrpcClients;
+using Gateway.API.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Gateway.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class TiposMaquinariaController : ControllerBase
+{
+    private readonly FuelGrpcClient _grpc;
+
+    public TiposMaquinariaController(FuelGrpcClient grpc)
+    {
+        _grpc = grpc;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Get()
+    {
+        var items = await _grpc.GetTiposAsync();
+        return Ok(items);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetById(int id)
+    {
+        var item = await _grpc.GetTipoByIdAsync(id);
+        if (item == null)
+            return NotFound();
+        return Ok(item);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] TipoMaquinariaCreateRequest request)
+    {
+        var created = await _grpc.CreateTipoAsync(request);
+        return Ok(created);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(int id, [FromBody] TipoMaquinariaUpdateRequest request)
+    {
+        var updated = await _grpc.UpdateTipoAsync(id, request);
+        return Ok(updated);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var ok = await _grpc.DeleteTipoAsync(id);
+        if (!ok) return NotFound();
+        return NoContent();
+    }
+}

--- a/api gateway/Gateway.API/Gateway.API/GrpcClients/FuelGrpcClient.cs
+++ b/api gateway/Gateway.API/Gateway.API/GrpcClients/FuelGrpcClient.cs
@@ -1,7 +1,7 @@
 using Grpc.Net.Client;
 using Gateway.API.Models;
 using Google.Protobuf.WellKnownTypes;
-using FuelService;
+using FuelProto = FuelService;
 using FuelRecordGrpc = FuelService.RegistroCombustibleDto;
 using FuelGrpcService = FuelService.FuelService;
 
@@ -35,5 +35,55 @@ public class FuelGrpcClient
             PrecioCombustible = r.PrecioCombustible,
             CostoTotal = r.CostoTotal
         });
+    }
+
+    public async Task<IEnumerable<TipoMaquinariaDto>> GetTiposAsync()
+    {
+        var response = await _client.ListarTiposMaquinariaAsync(new Empty());
+        return response.Tipos.Select(t => new TipoMaquinariaDto
+        {
+            TipoMaquinariaId = t.TipoMaquinariaId,
+            Nombre = t.Nombre
+        });
+    }
+
+    public async Task<TipoMaquinariaDto?> GetTipoByIdAsync(int id)
+    {
+        try
+        {
+            var t = await _client.ObtenerTipoMaquinariaAsync(new FuelProto.TipoMaquinariaIdRequest { TipoMaquinariaId = id });
+            return new TipoMaquinariaDto { TipoMaquinariaId = t.TipoMaquinariaId, Nombre = t.Nombre };
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<TipoMaquinariaDto> CreateTipoAsync(TipoMaquinariaCreateRequest request)
+    {
+        var res = await _client.CrearTipoMaquinariaAsync(new FuelProto.TipoMaquinariaCreateRequest { Nombre = request.Nombre });
+        return new TipoMaquinariaDto { TipoMaquinariaId = res.TipoMaquinariaId, Nombre = res.Nombre };
+    }
+
+    public async Task<TipoMaquinariaDto> UpdateTipoAsync(int id, TipoMaquinariaUpdateRequest request)
+    {
+        var grpc = new FuelProto.TipoMaquinariaUpdateRequest { TipoMaquinariaId = id };
+        if (request.Nombre != null) grpc.Nombre = request.Nombre;
+        var res = await _client.EditarTipoMaquinariaAsync(grpc);
+        return new TipoMaquinariaDto { TipoMaquinariaId = res.TipoMaquinariaId, Nombre = res.Nombre };
+    }
+
+    public async Task<bool> DeleteTipoAsync(int id)
+    {
+        try
+        {
+            await _client.EliminarTipoMaquinariaAsync(new FuelProto.TipoMaquinariaIdRequest { TipoMaquinariaId = id });
+            return true;
+        }
+        catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            return false;
+        }
     }
 }

--- a/api gateway/Gateway.API/Gateway.API/Models/TipoMaquinariaCreateRequest.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/TipoMaquinariaCreateRequest.cs
@@ -1,0 +1,6 @@
+namespace Gateway.API.Models;
+
+public class TipoMaquinariaCreateRequest
+{
+    public string Nombre { get; set; } = string.Empty;
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/TipoMaquinariaDto.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/TipoMaquinariaDto.cs
@@ -1,0 +1,7 @@
+namespace Gateway.API.Models;
+
+public class TipoMaquinariaDto
+{
+    public int TipoMaquinariaId { get; set; }
+    public string Nombre { get; set; } = string.Empty;
+}

--- a/api gateway/Gateway.API/Gateway.API/Models/TipoMaquinariaUpdateRequest.cs
+++ b/api gateway/Gateway.API/Gateway.API/Models/TipoMaquinariaUpdateRequest.cs
@@ -1,0 +1,6 @@
+namespace Gateway.API.Models;
+
+public class TipoMaquinariaUpdateRequest
+{
+    public string? Nombre { get; set; }
+}

--- a/api gateway/Gateway.API/Gateway.API/Protos/fuel.proto
+++ b/api gateway/Gateway.API/Gateway.API/Protos/fuel.proto
@@ -164,6 +164,22 @@ message ConsumoTipoMaquinariaUpdateRequest {
 
 message ListaConsumoTipoMaquinaria { repeated ConsumoTipoMaquinariaDto consumos = 1; }
 
+message TipoMaquinariaDto {
+  int32 tipoMaquinariaId = 1;
+  string nombre = 2;
+}
+
+message TipoMaquinariaCreateRequest { string nombre = 1; }
+
+message TipoMaquinariaIdRequest { int32 tipoMaquinariaId = 1; }
+
+message TipoMaquinariaUpdateRequest {
+  int32 tipoMaquinariaId = 1;
+  optional string nombre = 2;
+}
+
+message ListaTipoMaquinaria { repeated TipoMaquinariaDto tipos = 1; }
+
 service FuelService {
   // Registros de Combustible
   rpc CrearRegistro (RegistroCombustibleCreateRequest) returns (RegistroCombustibleDto);
@@ -185,4 +201,11 @@ service FuelService {
   rpc ListarConsumoTipoMaquinaria (google.protobuf.Empty) returns (ListaConsumoTipoMaquinaria);
   rpc EditarConsumoTipoMaquinaria (ConsumoTipoMaquinariaUpdateRequest) returns (ConsumoTipoMaquinariaDto);
   rpc EliminarConsumoTipoMaquinaria (ConsumoTipoMaquinariaIdRequest) returns (google.protobuf.Empty);
+
+  // Tipos de Maquinaria
+  rpc CrearTipoMaquinaria (TipoMaquinariaCreateRequest) returns (TipoMaquinariaDto);
+  rpc ObtenerTipoMaquinaria (TipoMaquinariaIdRequest) returns (TipoMaquinariaDto);
+  rpc ListarTiposMaquinaria (google.protobuf.Empty) returns (ListaTipoMaquinaria);
+  rpc EditarTipoMaquinaria (TipoMaquinariaUpdateRequest) returns (TipoMaquinariaDto);
+  rpc EliminarTipoMaquinaria (TipoMaquinariaIdRequest) returns (google.protobuf.Empty);
 }

--- a/fuel-service/fuel-service/Domain/Entities/TipoMaquinaria.cs
+++ b/fuel-service/fuel-service/Domain/Entities/TipoMaquinaria.cs
@@ -1,0 +1,7 @@
+namespace FuelService.Domain.Entities;
+
+public class TipoMaquinaria
+{
+    public int TipoMaquinariaId { get; set; }
+    public required string Nombre { get; set; }
+}

--- a/fuel-service/fuel-service/Persistence/FuelDbContext.cs
+++ b/fuel-service/fuel-service/Persistence/FuelDbContext.cs
@@ -10,12 +10,14 @@ public class FuelDbContext : DbContext
     public DbSet<RegistroCombustible> RegistrosCombustible => Set<RegistroCombustible>();
     public DbSet<ConsumoCombustibleRuta> ConsumosRuta => Set<ConsumoCombustibleRuta>();
     public DbSet<ConsumoCombustibleTipoMaquinaria> ConsumosTipoMaquinaria => Set<ConsumoCombustibleTipoMaquinaria>();
+    public DbSet<TipoMaquinaria> TiposMaquinaria => Set<TipoMaquinaria>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<RegistroCombustible>().ToTable("registros_combustible");
         modelBuilder.Entity<ConsumoCombustibleRuta>().ToTable("consumo_combustible_ruta");
         modelBuilder.Entity<ConsumoCombustibleTipoMaquinaria>().ToTable("consumo_combustible_tipo_maquinaria");
+        modelBuilder.Entity<TipoMaquinaria>().ToTable("tipo_maquinaria");
 
         var registro = modelBuilder.Entity<RegistroCombustible>();
         registro.HasKey(r => r.RegistroId);
@@ -71,5 +73,10 @@ public class FuelDbContext : DbContext
         maq.Property(m => m.PorcentajeDiferencia).HasColumnName("porcentaje_diferencia");
         maq.Property(m => m.CreadoEn).HasColumnName("creado_en");
         maq.Property(m => m.ActualizadoEn).HasColumnName("actualizado_en");
+
+        var tipo = modelBuilder.Entity<TipoMaquinaria>();
+        tipo.HasKey(t => t.TipoMaquinariaId);
+        tipo.Property(t => t.TipoMaquinariaId).HasColumnName("tipo_maquinaria_id");
+        tipo.Property(t => t.Nombre).HasColumnName("nombre");
     }
 }

--- a/fuel-service/fuel-service/Protos/fuel.proto
+++ b/fuel-service/fuel-service/Protos/fuel.proto
@@ -164,6 +164,22 @@ message ConsumoTipoMaquinariaUpdateRequest {
 
 message ListaConsumoTipoMaquinaria { repeated ConsumoTipoMaquinariaDto consumos = 1; }
 
+message TipoMaquinariaDto {
+  int32 tipoMaquinariaId = 1;
+  string nombre = 2;
+}
+
+message TipoMaquinariaCreateRequest { string nombre = 1; }
+
+message TipoMaquinariaIdRequest { int32 tipoMaquinariaId = 1; }
+
+message TipoMaquinariaUpdateRequest {
+  int32 tipoMaquinariaId = 1;
+  optional string nombre = 2;
+}
+
+message ListaTipoMaquinaria { repeated TipoMaquinariaDto tipos = 1; }
+
 service FuelService {
   // Registros de Combustible
   rpc CrearRegistro (RegistroCombustibleCreateRequest) returns (RegistroCombustibleDto);
@@ -185,4 +201,11 @@ service FuelService {
   rpc ListarConsumoTipoMaquinaria (google.protobuf.Empty) returns (ListaConsumoTipoMaquinaria);
   rpc EditarConsumoTipoMaquinaria (ConsumoTipoMaquinariaUpdateRequest) returns (ConsumoTipoMaquinariaDto);
   rpc EliminarConsumoTipoMaquinaria (ConsumoTipoMaquinariaIdRequest) returns (google.protobuf.Empty);
+
+  // Tipos de Maquinaria
+  rpc CrearTipoMaquinaria (TipoMaquinariaCreateRequest) returns (TipoMaquinariaDto);
+  rpc ObtenerTipoMaquinaria (TipoMaquinariaIdRequest) returns (TipoMaquinariaDto);
+  rpc ListarTiposMaquinaria (google.protobuf.Empty) returns (ListaTipoMaquinaria);
+  rpc EditarTipoMaquinaria (TipoMaquinariaUpdateRequest) returns (TipoMaquinariaDto);
+  rpc EliminarTipoMaquinaria (TipoMaquinariaIdRequest) returns (google.protobuf.Empty);
 }

--- a/fuel-service/fuel-service/Services/FuelGrpcService.cs
+++ b/fuel-service/fuel-service/Services/FuelGrpcService.cs
@@ -74,6 +74,12 @@ public class FuelGrpcService : FuelService.FuelServiceBase
         ActualizadoEn = c.ActualizadoEn != null ? Timestamp.FromDateTime(c.ActualizadoEn.Value.ToUniversalTime()) : null
     };
 
+    private static TipoMaquinariaDto ToDto(TipoMaquinaria t) => new()
+    {
+        TipoMaquinariaId = t.TipoMaquinariaId,
+        Nombre = t.Nombre
+    };
+
     // Registros CRUD
     public override async Task<RegistroCombustibleDto> CrearRegistro(RegistroCombustibleCreateRequest request, ServerCallContext context)
     {
@@ -291,6 +297,51 @@ public class FuelGrpcService : FuelService.FuelServiceBase
         if (entity == null)
             throw new RpcException(new Status(StatusCode.NotFound, "Consumo no encontrado"));
         _context.ConsumosTipoMaquinaria.Remove(entity);
+        await _context.SaveChangesAsync();
+        return new Empty();
+    }
+
+    // Tipo Maquinaria CRUD
+    public override async Task<TipoMaquinariaDto> CrearTipoMaquinaria(TipoMaquinariaCreateRequest request, ServerCallContext context)
+    {
+        var entity = new TipoMaquinaria { Nombre = request.Nombre };
+        _context.TiposMaquinaria.Add(entity);
+        await _context.SaveChangesAsync();
+        return ToDto(entity);
+    }
+
+    public override async Task<TipoMaquinariaDto> ObtenerTipoMaquinaria(TipoMaquinariaIdRequest request, ServerCallContext context)
+    {
+        var entity = await _context.TiposMaquinaria.FindAsync(request.TipoMaquinariaId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Tipo no encontrado"));
+        return ToDto(entity);
+    }
+
+    public override async Task<ListaTipoMaquinaria> ListarTiposMaquinaria(Empty request, ServerCallContext context)
+    {
+        var list = await _context.TiposMaquinaria.ToListAsync();
+        var res = new ListaTipoMaquinaria();
+        res.Tipos.AddRange(list.Select(ToDto));
+        return res;
+    }
+
+    public override async Task<TipoMaquinariaDto> EditarTipoMaquinaria(TipoMaquinariaUpdateRequest request, ServerCallContext context)
+    {
+        var entity = await _context.TiposMaquinaria.FindAsync(request.TipoMaquinariaId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Tipo no encontrado"));
+        if (request.HasNombre) entity.Nombre = request.Nombre;
+        await _context.SaveChangesAsync();
+        return ToDto(entity);
+    }
+
+    public override async Task<Empty> EliminarTipoMaquinaria(TipoMaquinariaIdRequest request, ServerCallContext context)
+    {
+        var entity = await _context.TiposMaquinaria.FindAsync(request.TipoMaquinariaId);
+        if (entity == null)
+            throw new RpcException(new Status(StatusCode.NotFound, "Tipo no encontrado"));
+        _context.TiposMaquinaria.Remove(entity);
         await _context.SaveChangesAsync();
         return new Empty();
     }


### PR DESCRIPTION
## Summary
- add TipoMaquinaria entity and EF mappings
- extend gRPC protos with TipoMaquinaria messages and RPCs
- implement TipoMaquinaria CRUD in FuelGrpcService
- support TipoMaquinaria operations in FuelGrpcClient
- expose HTTP endpoints via new TiposMaquinariaController

## Testing
- `dotnet build fuel-service/fuel-service.sln`
- `dotnet build 'api gateway'/Gateway.API/Gateway.API.sln`


------
https://chatgpt.com/codex/tasks/task_e_686b3b5f0c34833386961df829c395e8