### PR TITLE
Fix vehicle creation when referencing machinery type

### DIFF
--- a/vehicles-service/vehicle-service/vehicle-service/Services/VehiculoGrpcService.cs
+++ b/vehicles-service/vehicle-service/vehicle-service/Services/VehiculoGrpcService.cs
@@ -24,6 +24,11 @@ namespace VehicleService.Services
                 if (await _context.Vehiculos.AnyAsync(v => v.Placa == request.Placa))
                     throw new RpcException(new Status(StatusCode.AlreadyExists, "Ya existe un vehículo con esa placa."));
 
+                // Validar existencia del tipo de maquinaria solicitado
+                bool tipoExiste = await _context.TipoVehiculos.AnyAsync(t => t.Id == request.TipoMaquinariaId);
+                if (!tipoExiste)
+                    throw new RpcException(new Status(StatusCode.NotFound, "Tipo de maquinaria no encontrado"));
+
                 var vehiculo = new Vehiculo
                 {
                     Placa = request.Placa,


### PR DESCRIPTION
## Summary
- validate the machinery type exists before creating a vehicle

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b6b878a3883339db5b003c2f7246a